### PR TITLE
pin nostr-tools to 2.1.5 and depend on nostr-wasm explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "type": "module",
   "dependencies": {
     "debounce": "^1.2.1",
-    "nostr-tools": "^2.1.5",
+    "nostr-tools": "2.1.5",
+    "nostr-wasm": "0.1.0",
     "s-ago": "^2.2.0"
   }
 }


### PR DESCRIPTION
The code uses the nostr-tools 2.1.x nip29 API, but "^2.1.5" with a gitignored lockfile resolves to 2.24.x on a fresh install, where that API no longer exists and the build breaks. Pin the version and declare nostr-wasm, which is imported directly.