### PR TITLE
add CI running svelte-check, tests and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run check
+      - run: npm test
+      - run: npm run build

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --plugin-search-dir . --check . && eslint .",
-    "format": "prettier --plugin-search-dir . --write ."
+    "format": "prettier --plugin-search-dir . --write .",
+    "test": "vitest run"
   },
   "peerDependencies": {
     "typescript": ">=5.0.0"
@@ -37,7 +38,8 @@
     "svelte-eslint-parser": "^0.33.0",
     "tailwindcss": "^3.3.2",
     "tslib": "^2.4.1",
-    "vite": "^4.4.2"
+    "vite": "^4.4.2",
+    "vitest": "^4.1.10"
   },
   "type": "module",
   "dependencies": {

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it, vi, beforeEach, afterEach} from 'vitest'
+import {get} from 'svelte/store'
+
+import {humanDate, showToast, toastState} from './utils.ts'
+
+describe('humanDate', () => {
+  it('shows a relative time for recent events', () => {
+    const tenMinutesAgo = Math.round(Date.now() / 1000) - 600
+    expect(humanDate(tenMinutesAgo)).toMatch(/ago/)
+  })
+
+  it('shows an absolute date for events older than 60 hours', () => {
+    const longAgo = Math.round(new Date('2024-03-05T10:00:00Z').getTime() / 1000)
+    // "Mar 05 2024", without the weekday
+    expect(humanDate(longAgo)).toMatch(/^[A-Z][a-z]{2} \d{2} \d{4}$/)
+  })
+})
+
+describe('showToast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    toastState.set(null)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows a toast and clears it when its time is up', () => {
+    showToast({type: 'normal', text: 'first'}, 1000)
+    expect(get(toastState)?.text).toBe('first')
+
+    vi.advanceTimersByTime(1000)
+    expect(get(toastState)).toBe(null)
+  })
+})

--- a/src/pages/ChatPage.svelte
+++ b/src/pages/ChatPage.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import {afterUpdate, onMount} from 'svelte'
   import {debounce} from 'debounce'
-  import type {Event} from 'nostr-tools/wasm'
+  import type {Event, VerifiedEvent} from 'nostr-tools/wasm'
   import {normalizeURL} from 'nostr-tools/utils'
   import type {AbstractRelay, Subscription} from 'nostr-tools/abstract-relay'
   import {
@@ -141,9 +141,11 @@
           onclose(reason) {
             console.warn(relay.url, 'relay connection closed', reason)
             if (reason.includes('auth-required')) {
-              relay.auth(async (evt) => await signer.signEvent(evt)).then(() => {
-                loadChat()
-              })
+              relay
+                .auth(evt => signer.signEvent(evt) as Promise<VerifiedEvent>)
+                .then(() => {
+                  loadChat()
+                })
             }
           }
         }
@@ -170,7 +172,7 @@
       text = ''
       saveToLocalStorage()
       isSending = false
-    } catch (err) {
+    } catch (err: any) {
       console.warn('failed to ask to join', err)
       console.warn(err.stack)
       showToast({type: 'error', text: String(err)})
@@ -193,7 +195,7 @@
       text = ''
       saveToLocalStorage()
       isSending = false
-    } catch (err) {
+    } catch (err: any) {
       console.warn('failed to send', err)
       console.warn(err.stack)
       showToast({type: 'error', text: String(err)})
@@ -217,7 +219,7 @@
           },
           relay.url
         )
-      } catch (err) {
+      } catch (err: any) {
         console.warn('failed to delete', err)
         console.warn(err.stack)
         showToast({type: 'error', text: String(err)})
@@ -245,7 +247,7 @@
           type: 'success',
           text: 'successfully banned ' + member.pubkey
         })
-      } catch (err) {
+      } catch (err: any) {
         console.warn('failed to ban', err)
         console.warn(err.stack)
         showToast({type: 'error', text: String(err)})


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs svelte-check, vitest and the build on pushes and pull requests, plus the first unit tests (humanDate and the toast store). svelte-check reported five pre-existing errors in ChatPage, so those are fixed here to let it gate CI.