### PR TITLE
actually await multi-relay publishes

### DIFF
--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -148,14 +148,17 @@ export async function publish(
   relay: string | string[]
 ): Promise<void> {
   const event = await signer.signEvent(unsignedEvent)
-  if (Array.isArray(relay)) {
-    relay.forEach(async url => {
+  const relays = Array.isArray(relay) ? relay : [relay]
+  const results = await Promise.allSettled(
+    relays.map(async url => {
       const r = await pool.ensureRelay(url)
       await r.publish(event)
     })
-  } else {
-    const r = await pool.ensureRelay(relay)
-    await r.publish(event)
+  )
+  // succeed if at least one relay accepted the event
+  if (!results.some(res => res.status === 'fulfilled')) {
+    const first = results[0] as PromiseRejectedResult | undefined
+    throw first ? first.reason : new Error('no relays to publish to')
   }
 }
 


### PR DESCRIPTION
publish() used relay.forEach(async ...), so it returned before any relay was contacted and every failure became an unhandled rejection: saving the groups list looked successful even when no relay accepted it. Await all relays and succeed when at least one does.