### PR TITLE
fix groups list mutation, duplicates and tag matching

### DIFF
--- a/src/components/GroupsList.svelte
+++ b/src/components/GroupsList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type {Group} from 'nostr-tools/nip29'
-  import type {Event} from 'nostr-tools/wasm'
+  import {normalizeURL} from 'nostr-tools/utils'
   import * as nip19 from 'nostr-tools/nip19'
 
   import {account, defaultRelays, publish} from '../lib/nostr.ts'
@@ -8,26 +8,65 @@
 
   export let current: Group | null = null
 
-  function naddrEncode(group: Group): string {
-    let relay = group.relay as string
-    return nip19.naddrEncode({
-      kind: 39000,
-      relays: [relay],
-      pubkey: $account?.pubkey as string,
-      identifier: group.id
-    })
+  function sameRelay(a: string | undefined, b: string | undefined): boolean {
+    if (!a || !b) return a === b
+    try {
+      return normalizeURL(a) === normalizeURL(b)
+    } catch (err) {
+      return a === b
+    }
+  }
+
+  function sameGroup(a: Group, b: Group): boolean {
+    return a.id === b.id && sameRelay(a.relay, b.relay)
+  }
+
+  function groupLink(group: Group): string {
+    if (group.pubkey) {
+      try {
+        return (
+          '/' +
+          nip19.naddrEncode({
+            kind: 39000,
+            relays: [group.relay],
+            pubkey: group.pubkey,
+            identifier: group.id
+          })
+        )
+      } catch (err) {
+        /* fall through to the plain host'id form */
+      }
+    }
+    const host = (group.relay || '')
+      .replace(/^wss?:\/\//, '')
+      .replace(/\/$/, '')
+    return `/${host}'${group.id}`
+  }
+
+  function publishRelays(): string[] {
+    const writeRelays = $account?.writeRelays
+    return writeRelays && writeRelays.length ? writeRelays : defaultRelays
   }
 
   async function addGroupToList() {
     if (!current) return
 
-    // we save this group to our list no matter what
-    let {tags, content}: Pick<Event, 'content' | 'tags'> =
-      $account?.lastGroupsList || {
-        content: '',
-        tags: []
-      }
-    tags.push(['group', current.id, current.relay as string])
+    const listEvent = $account?.lastGroupsList
+    // work on a copy: mutating the store's event would corrupt local
+    // state even when the publish fails
+    const content = listEvent?.content || ''
+    const tags = (listEvent?.tags || []).map(tag => [...tag])
+
+    const relayURL = current.relay as string
+    const exists = tags.some(
+      tag =>
+        tag[0] === 'group' &&
+        tag[1] === current?.id &&
+        sameRelay(tag[2], relayURL)
+    )
+    if (exists) return
+
+    tags.push(['group', current.id, relayURL])
     try {
       await publish(
         {
@@ -36,7 +75,7 @@
           tags,
           created_at: Math.round(Date.now() / 1000)
         },
-        $account?.writeRelays || defaultRelays
+        publishRelays()
       )
     } catch (err) {
       console.warn('failed to publish groups list', err)
@@ -45,28 +84,34 @@
   }
 
   async function removeGroupFromList(group: Group) {
-    let listEvent = $account?.lastGroupsList
+    const listEvent = $account?.lastGroupsList
     if (!listEvent) return
 
-    let {tags, content} = listEvent
+    const content = listEvent.content
+    const tags = listEvent.tags.map(tag => [...tag])
 
-    let idx = listEvent.tags.findIndex(tag => tag[1] === group.id)
-    if (idx !== -1) {
-      tags.splice(idx, 1)
-      try {
-        await publish(
-          {
-            kind: 10009,
-            content,
-            tags,
-            created_at: Math.round(Date.now() / 1000)
-          },
-          $account?.writeRelays || defaultRelays
-        )
-      } catch (err) {
-        console.warn('failed to publish groups list', err)
-        showToast({type: 'error', text: String(err)})
-      }
+    const idx = tags.findIndex(
+      tag =>
+        tag[0] === 'group' &&
+        tag[1] === group.id &&
+        (tag.length < 3 || sameRelay(tag[2], group.relay))
+    )
+    if (idx === -1) return
+
+    tags.splice(idx, 1)
+    try {
+      await publish(
+        {
+          kind: 10009,
+          content,
+          tags,
+          created_at: Math.round(Date.now() / 1000)
+        },
+        publishRelays()
+      )
+    } catch (err) {
+      console.warn('failed to publish groups list', err)
+      showToast({type: 'error', text: String(err)})
     }
   }
 </script>
@@ -74,24 +119,27 @@
 <div class="flex flex-col pr-8">
   <h3 class="text-lg text-emerald-600 mb-2">groups</h3>
 
-  {#if current && $account && $account.groups.findIndex(g => g.id === current?.id) === -1}
+  {#if current && $account && !$account.groups.some(g => current && sameGroup(g, current))}
     <button
       class="p-1 my-2 text-xs bg-blue-500 hover:bg-blue-400 text-white rounded transition-colors"
       on:click={addGroupToList}>add this group to list?</button
     >
   {/if}
 
-  {#each $account?.groups || [] as group (group.id)}
-    <div class="flex px-1" class:bg-emerald-200={group.id === current?.id}>
+  {#each $account?.groups || [] as group (`${group.relay}'${group.id}`)}
+    <div
+      class="flex px-1"
+      class:bg-emerald-200={current && sameGroup(group, current)}
+    >
       {#if group.picture}
         <img src={group.picture} alt="group" />
       {/if}
-      {#if group.id !== current?.id}
-        <a class="cursor-pointer hover:underline" href={naddrEncode(group)}
-          >{group.name}</a
+      {#if !current || !sameGroup(group, current)}
+        <a class="cursor-pointer hover:underline" href={groupLink(group)}
+          >{group.name || group.id}</a
         >
       {:else}
-        <span>{group.name}</span>
+        <span>{group.name || group.id}</span>
       {/if}
       <!-- svelte-ignore a11y-no-static-element-interactions a11y-missing-attribute -->
       <!-- svelte-ignore a11y-click-events-have-key-events -->


### PR DESCRIPTION
addGroupToList and removeGroupFromList mutated the tags of the stored groups-list event, so local state changed even when the publish failed, and adding a group already in the list appended a duplicate. Work on a copy and compare relays normalised.