### PR TITLE
give queued toasts their display time

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -32,4 +32,22 @@ describe('showToast', () => {
     vi.advanceTimersByTime(1000)
     expect(get(toastState)).toBe(null)
   })
+
+  it('gives a queued toast its own display time', () => {
+    showToast({type: 'normal', text: 'first'}, 1000)
+    showToast({type: 'error', text: 'second'}, 1000)
+
+    vi.advanceTimersByTime(999)
+    expect(get(toastState)?.text).toBe('first')
+
+    vi.advanceTimersByTime(1)
+    expect(get(toastState)?.text).toBe('second')
+
+    // the queued toast used to be replaced within the same tick
+    vi.advanceTimersByTime(999)
+    expect(get(toastState)?.text).toBe('second')
+
+    vi.advanceTimersByTime(1)
+    expect(get(toastState)).toBe(null)
+  })
 })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -28,7 +28,7 @@ function onToastEnd() {
   const next = nextToasts.shift()
   if (next) {
     toastState.set(next.state)
-    setTimeout(onToastEnd)
+    setTimeout(onToastEnd, next.timeout)
   } else {
     toastState.set(null)
   }


### PR DESCRIPTION
onToastEnd scheduled the next one with no delay, so a toast that arrived while another was showing was replaced within the same tick and was never actually visible. Use the queued toast's own timeout, with a regression test.