### PR TITLE
fix relay host validation and close subscription on destroy

### DIFF
--- a/src/pages/SelectPage.svelte
+++ b/src/pages/SelectPage.svelte
@@ -11,7 +11,7 @@
   import {pool} from '../lib/nostr.ts'
   import Header from '../components/Header.svelte'
   import GroupsList from '../components/GroupsList.svelte'
-  import {afterUpdate} from 'svelte'
+  import {afterUpdate, onDestroy} from 'svelte'
 
   export let initialHost: string | null = null
 
@@ -30,8 +30,13 @@
     }
   })
 
+  onDestroy(() => {
+    if (cancel) cancel()
+  })
+
   const tryConnect = debounce(async () => {
-    if (gr.host.length < 5 && gr.host.split('.').length < 2) return
+    // wait until the input looks like a host at all
+    if (gr.host.length < 5 || gr.host.split('.').length < 2) return
 
     if (cancel) {
       cancel()


### PR DESCRIPTION
The host guard used && so almost any short input passed it and triggered connection attempts while typing; require both a minimum length and a dot. Also cancel the relay groups subscription when the page is destroyed.