### PR TITLE
Serve as a static SPA and accept group codes containing slashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
+    "build": "vite build && cp build/404.html build/index.html",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^2.1.0",
+    "@sveltejs/adapter-static": "^2.0.3",
     "@sveltejs/kit": "^1.20.4",
     "@tailwindcss/forms": "^0.5.6",
     "@tailwindcss/typography": "^0.5.9",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,21 @@
 <script lang="ts">
+  import {afterNavigate, goto} from '$app/navigation'
+
   import SelectPage from '../pages/SelectPage.svelte'
+
+  // opening the app at `/` jumps straight back into the last visited
+  // group — but only once per tab: reaching `/` from inside the app
+  // (e.g. the header logo) or reloading it afterwards must show the
+  // selection page, otherwise there is no way to switch relays
+  afterNavigate(nav => {
+    if (nav.from !== null) return
+    if (sessionStorage.getItem('autoResumed')) return
+    const last = localStorage.getItem('lastGroupCode')
+    if (last) {
+      sessionStorage.setItem('autoResumed', '1')
+      goto('/' + last, {replaceState: true})
+    }
+  })
 </script>
 
 <SelectPage />

--- a/src/routes/[...code]/+page.svelte
+++ b/src/routes/[...code]/+page.svelte
@@ -27,17 +27,24 @@
         let {relays, identifier} = data as nip19.AddressPointer
         if (!relays || relays.length === 0) return
 
-        host = relays[0].replace(/^wss?:\/\//, '')
+        host = relays[0].replace(/^wss?:\/\//, '').replace(/\/+$/, '')
         id = identifier
       } catch (err) {
         console.warn('invalid naddr', code, err)
       }
     } else if (code.split("'").length === 2) {
       let spl = code.split("'")
-      host = spl[0]
+      // hosts copied from relay URLs may carry a trailing slash (the
+      // route is a rest parameter exactly so such codes still match)
+      host = spl[0].replace(/\/+$/, '')
       id = spl[1]
     } else if (code.split('.').length > 1) {
-      host = code
+      host = code.replace(/\/+$/, '')
+    }
+
+    // remember the last opened group so `/` can jump straight back to it
+    if (host && id) {
+      localStorage.setItem('lastGroupCode', code)
     }
   })
 </script>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-auto'
+import adapter from '@sveltejs/adapter-static'
 import {vitePreprocess} from '@sveltejs/kit/vite'
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -6,7 +6,10 @@ const config = {
   preprocess: [vitePreprocess({})],
 
   kit: {
-    adapter: adapter()
+    // 404.html is the SPA fallback served by clask for unknown paths
+    // (deep links like /<relay>'<group>); index.html is a copy of it made
+    // in the build script so the root path still gets a 200
+    adapter: adapter({fallback: '404.html'})
   }
 }
 


### PR DESCRIPTION
Build with adapter-static so the app can be served as a plain SPA, and accept group codes whose relay host carries a trailing slash by making the route a rest parameter.