### PR TITLE
Support more signers and resolve profiles and group names reliably

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "type": "module",
   "dependencies": {
     "debounce": "^1.2.1",
+    "nostr-login": "^1.7.12",
     "nostr-tools": "2.1.5",
     "nostr-wasm": "0.1.0",
     "s-ago": "^2.2.0"

--- a/src/components/GroupsList.svelte
+++ b/src/components/GroupsList.svelte
@@ -3,10 +3,66 @@
   import {normalizeURL} from 'nostr-tools/utils'
   import * as nip19 from 'nostr-tools/nip19'
 
-  import {account, defaultRelays, publish} from '../lib/nostr.ts'
+  import {
+    account,
+    defaultRelays,
+    publish,
+    getMetadata,
+    profileRelays,
+    type ChatGroup
+  } from '../lib/nostr.ts'
   import {showToast} from '$lib/utils.ts'
 
   export let current: Group | null = null
+
+  // Buzz names every DM channel "DM", so several entries in the list can
+  // share a name. Those get the other participant's name appended.
+  let counterparts: Record<string, string> = {}
+
+  $: groups = ($account?.groups || []) as ChatGroup[]
+  $: duplicatedNames = new Set(
+    groups
+      .map(g => g.name)
+      .filter(
+        (name, i, all) => !!name && all.indexOf(name) !== all.lastIndexOf(name)
+      ) as string[]
+  )
+  $: if (duplicatedNames.size) resolveCounterparts(groups)
+
+  function groupKey(g: Group): string {
+    return `${g.relay}'${g.id}`
+  }
+
+  async function resolveCounterparts(list: ChatGroup[]) {
+    for (const g of list) {
+      const key = groupKey(g)
+      if (!g.name || !duplicatedNames.has(g.name)) continue
+      if (counterparts[key] !== undefined) continue
+      const other = (g.participants || []).find(p => p !== $account?.pubkey)
+      if (!other) continue
+      counterparts[key] = '' // don't look the same pubkey up twice
+      try {
+        const md = await getMetadata(other, [
+          ...(g.relay ? [g.relay] : []),
+          ...profileRelays
+        ])
+        const name = md.name?.trim() || md.display_name?.trim()
+        counterparts[key] = name || nip19.npubEncode(other).slice(0, 11)
+        counterparts = counterparts
+      } catch (err) {
+        /* leave it unlabelled */
+      }
+    }
+  }
+
+  // what the sidebar shows for a group: its name, plus the other
+  // participant when the name alone is ambiguous
+  function displayName(g: ChatGroup): string {
+    const base = g.name || g.id
+    if (!g.name || !duplicatedNames.has(g.name)) return base
+    const who = counterparts[groupKey(g)]
+    return who ? `${base} · ${who}` : base
+  }
 
   function sameRelay(a: string | undefined, b: string | undefined): boolean {
     if (!a || !b) return a === b
@@ -116,41 +172,66 @@
   }
 </script>
 
-<div class="flex flex-col pr-8">
-  <h3 class="text-lg text-emerald-600 mb-2">groups</h3>
+<div class="flex w-full flex-col">
+  <h3 class="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+    your groups
+  </h3>
 
-  {#if current && $account && !$account.groups.some(g => current && sameGroup(g, current))}
-    <button
-      class="p-1 my-2 text-xs bg-blue-500 hover:bg-blue-400 text-white rounded transition-colors"
-      on:click={addGroupToList}>add this group to list?</button
-    >
+  {#if !$account}
+    <div class="text-sm leading-relaxed text-slate-400">
+      login (top right) to keep a list of your groups here
+    </div>
+  {:else if !$account.groups.length && !current}
+    <div class="text-sm leading-relaxed text-slate-400">
+      no groups saved yet — join a group and add it to your list
+    </div>
   {/if}
 
-  {#each $account?.groups || [] as group (`${group.relay}'${group.id}`)}
+  {#each groups as group (`${group.relay}'${group.id}`)}
     <div
-      class="flex px-1"
-      class:bg-emerald-200={current && sameGroup(group, current)}
+      class="group flex items-center justify-between gap-1 rounded-lg px-2 py-1.5 text-sm transition-colors"
+      class:bg-indigo-50={current && sameGroup(group, current)}
+      class:text-indigo-700={current && sameGroup(group, current)}
+      class:hover:bg-slate-100={!current || !sameGroup(group, current)}
     >
-      {#if group.picture}
-        <img src={group.picture} alt="group" />
-      {/if}
-      {#if !current || !sameGroup(group, current)}
-        <a class="cursor-pointer hover:underline" href={groupLink(group)}
-          >{group.name || group.id}</a
-        >
-      {:else}
-        <span>{group.name || group.id}</span>
-      {/if}
+      <div class="flex min-w-0 items-center gap-2">
+        {#if group.picture}
+          <img
+            class="h-5 w-5 shrink-0 rounded object-cover"
+            src={group.picture}
+            alt="group"
+          />
+        {/if}
+        {#if !current || !sameGroup(group, current)}
+          <a
+            class="cursor-pointer truncate hover:underline"
+            title={group.id}
+            href={groupLink(group)}>#{displayName(group)}</a
+          >
+        {:else}
+          <span class="truncate font-medium" title={group.id}
+            >#{displayName(group)}</span
+          >
+        {/if}
+      </div>
       <!-- svelte-ignore a11y-no-static-element-interactions a11y-missing-attribute -->
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <a
-        class="hover:text-red-600 text-stone-400 cursor-pointer ml-1"
+        class="cursor-pointer text-slate-300 opacity-0 transition-opacity hover:text-red-500 group-hover:opacity-100"
         on:click={() => removeGroupFromList(group)}
         title="remove group from list"
       >
         ×
       </a>
-      &nbsp;
     </div>
   {/each}
+
+  <!-- kept below the list: toggling this button while switching groups
+       must not shift the group rows above it -->
+  {#if current && $account && !$account.groups.some(g => current && sameGroup(g, current))}
+    <button
+      class="my-2 rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white shadow-sm transition-colors hover:bg-indigo-500"
+      on:click={addGroupToList}>add this group to list?</button
+    >
+  {/if}
 </div>

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -3,32 +3,41 @@
   import {account, signer} from '../lib/nostr.ts'
 </script>
 
-<div class="flex justify-between">
-  <div>
-    <a href="/" class="text-stone-600 text-lg hover:underline">chat29</a>
-    <span class="text-xs"
-      >: <a
-        href="https://github.com/nostr-protocol/nips/blob/simple-chat-groups/29.md"
-        class="text-rose-500 hover:underline"
-        target="_blank">NIP-29</a
-      >-based barebones chat client.
-    </span>
+<div class="flex items-center justify-between gap-4">
+  <div class="flex items-center gap-3">
+    <a href="/" class="flex items-center gap-2">
+      <span
+        class="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-indigo-500 to-violet-500 text-sm font-bold text-white shadow-sm"
+        >29</span
+      >
+      <span class="text-lg font-semibold tracking-tight text-slate-900"
+        >chat29</span
+      >
+    </a>
+    <a
+      href="https://github.com/nostr-protocol/nips/blob/simple-chat-groups/29.md"
+      target="_blank"
+      class="hidden rounded-full border border-slate-200 bg-white px-2.5 py-0.5 text-xs font-medium text-slate-500 transition-colors hover:border-indigo-300 hover:text-indigo-600 sm:inline-block"
+      >NIP-29</a
+    >
   </div>
-  <div class="w-1/6">
+  <div class="shrink-0">
     {#if $account}
-      <div class="flex items-center">
+      <div
+        class="flex items-center gap-3 rounded-full border border-slate-200 bg-white py-1 pl-1.5 pr-3 shadow-sm"
+      >
         <UserLabel pubkey={$account.pubkey} />
         <button
-          class="ml-2 hover:underline text-stone-300 cursor-pointer text-sm"
+          class="text-xs text-slate-400 transition-colors hover:text-slate-600"
           on:click={() => signer.signOut()}>logout</button
         >
       </div>
     {:else}
       <button
-        class="h-full w-full px-2 py-1 text-sm text-white rounded transition-colors bg-rose-500 hover:bg-rose-700"
+        class="rounded-full bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-indigo-500"
         on:click={() => signer.getPublicKey()}
       >
-        login with public key
+        login
       </button>
     {/if}
   </div>

--- a/src/components/MemberLabel.svelte
+++ b/src/components/MemberLabel.svelte
@@ -5,6 +5,7 @@
 
   export let member: Member
   export let canBan: boolean = false
+  export let relays: string[] | undefined = undefined
 
   const dispatch = createEventDispatcher()
 
@@ -14,7 +15,7 @@
 </script>
 
 <div class="flex items-center">
-  <UserLabel pubkey={member.pubkey} />
+  <UserLabel pubkey={member.pubkey} {relays} />
   {#if canBan}
     <!-- svelte-ignore a11y-no-static-element-interactions a11y-missing-attribute -->
     <!-- svelte-ignore a11y-click-events-have-key-events -->

--- a/src/components/UserLabel.svelte
+++ b/src/components/UserLabel.svelte
@@ -5,47 +5,57 @@
   import {getMetadata, type Metadata} from '../lib/nostr.ts'
 
   export let pubkey: string
+  // relays to look the profile up on; when omitted the public profile
+  // relays are used (see getMetadata)
+  export let relays: string[] | undefined = undefined
   let metadata: Metadata
   let npub = nip19.npubEncode(pubkey)
-  let imgError = false
+  // index into the picture candidates; bumped when an image fails to
+  // load so the next known URL gets a chance
+  let pictureIdx = 0
 
   $: name =
-    metadata?.name && metadata.name.trim() !== ''
-      ? metadata.name
-      : npub.slice(0, 11)
-  $: picture = imgError ? null : metadata?.picture
+    metadata?.name?.trim() ||
+    metadata?.display_name?.trim() ||
+    npub.slice(0, 11)
+  $: pictureCandidates = metadata?.pictures?.length
+    ? metadata.pictures
+    : metadata?.picture
+      ? [metadata.picture]
+      : []
+  $: picture = pictureCandidates[pictureIdx] ?? null
 
   onMount(async () => {
-    metadata = await getMetadata(pubkey)
+    metadata = await getMetadata(pubkey, relays)
   })
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions a11y-click-events-have-key-events -->
 <div
-  class="flex items-center cursor-pointer"
+  class="flex min-w-0 cursor-pointer items-center gap-1.5"
   on:click={() => window.open('https://nosta.me/' + pubkey)}
   title={npub}
 >
-  <div class="h-6 mr-1">
+  <div class="h-6 w-6 shrink-0">
     {#if picture}
       <img
-        class="aspect-square h-full border border-stone-300 object-cover"
+        class="aspect-square h-full w-full rounded-full border border-slate-200 bg-slate-100 object-cover"
         src={picture}
         alt="user avatar"
         on:error={() => {
-          imgError = true
+          pictureIdx++
         }}
-      />&nbsp;
+      />
     {:else}
       <img
-        class="aspect-square h-full border border-stone-300 object-cover"
+        class="aspect-square h-full w-full rounded-full border border-slate-200 bg-slate-200 object-cover"
         alt="empty user avatar"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
       />
     {/if}
   </div>
   <div
-    class="text-ellipsis overflow-hidden text-rose-700 text-lg pl-1"
+    class="truncate text-sm font-medium text-slate-700 transition-colors hover:text-indigo-600"
     title={npub}
   >
     {name}

--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -2,16 +2,25 @@ import {
   setNostrWasm,
   type EventTemplate,
   type Event,
+  type VerifiedEvent,
   verifyEvent
 } from 'nostr-tools/wasm'
 import {AbstractSimplePool} from 'nostr-tools/abstract-pool'
+import type {AbstractRelay, Subscription} from 'nostr-tools/abstract-relay'
+import {normalizeURL} from 'nostr-tools/utils'
 import {initNostrWasm} from 'nostr-wasm'
+import {init as initNostrLogin, logout as nostrLoginLogout} from 'nostr-login'
 import {readable} from 'svelte/store'
-import {parseGroup, type Group} from 'nostr-tools/nip29'
+import {parseGroup, parseMembers, type Group} from 'nostr-tools/nip29'
+
+// a group plus the member pubkeys the relay reported for it: Buzz names
+// every DM channel "DM", so the participants are the only way to tell
+// them apart in a list
+export type ChatGroup = Group & {participants?: string[]}
 
 export type Metadata = {
   pubkey: string
-  groups: Group[]
+  groups: ChatGroup[]
   writeRelays: string[]
   lastGroupsList?: Event
   name?: string
@@ -19,9 +28,78 @@ export type Metadata = {
   nip05?: string
   nip05valid: boolean
   picture?: string
+  // every picture URL seen across profile versions, newest first — the
+  // UI falls back to the next one when an image fails to load
+  pictures?: string[]
 }
 
 initNostrWasm().then(setNostrWasm)
+
+// nostr-login only shows its dialog after it has looked up the NIP-05
+// service info of the remote signers it offers (nsec.app and friends).
+// On a network where such a provider is unreachable that fetch hangs for
+// the browser's full connect timeout and the login dialog never appears,
+// so bound those lookups — a missing provider entry is harmless.
+if (typeof window !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+  const originalFetch = window.fetch.bind(window)
+  window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url
+    if (url.includes('/.well-known/nostr.json') && !init?.signal) {
+      return originalFetch(input, {...init, signal: AbortSignal.timeout(3000)})
+    }
+    return originalFetch(input, init)
+  }
+}
+
+// nostr-login provides window.nostr for users without an extension:
+// remote signers (nip46), a locally stored key or read-only mode all
+// end up behind the same interface, so nothing below needs to know
+// which one the user picked
+initNostrLogin({
+  theme: 'default',
+  // asking up front keeps remote signers from prompting mid-conversation:
+  // 9/10 chat, 7 reactions, 5 + 9005 delete, 9021 join, 9001/9006
+  // moderation, 10009 group list, 22242 relay auth, 24242 media
+  // authorization
+  perms: [
+    'sign_event:0',
+    'sign_event:5',
+    'sign_event:7',
+    'sign_event:9',
+    'sign_event:10',
+    'sign_event:9001',
+    'sign_event:9005',
+    'sign_event:9006',
+    'sign_event:9021',
+    'sign_event:10009',
+    'sign_event:22242',
+    'sign_event:24242'
+  ].join(',')
+}).catch((err: unknown) => {
+  console.warn('failed to initialize nostr-login', err)
+})
+
+// the user can log out (or switch accounts) from nostr-login's own UI
+document.addEventListener('nlAuth', ((e: CustomEvent) => {
+  const detail = e.detail
+  if (detail?.type === 'logout') {
+    removeAccount()
+  } else if (detail?.pubkey) {
+    initializeAccount(detail.pubkey)
+  } else {
+    // login/signup without a pubkey in the payload: ask the signer
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).nostr
+      ?.getPublicKey()
+      .then((pubkey: string) => initializeAccount(pubkey))
+      .catch((err: unknown) => console.warn('failed to read pubkey', err))
+  }
+}) as EventListener)
 
 export const pool = new AbstractSimplePool({verifyEvent})
 
@@ -41,6 +119,12 @@ export const signer = {
     return se
   },
   signOut: (): void => {
+    // also drops nostr-login's session (nip46 connection, stored key)
+    try {
+      nostrLoginLogout()
+    } catch (err) {
+      console.warn('failed to log out of nostr-login', err)
+    }
     removeAccount()
   }
 }
@@ -126,8 +210,9 @@ export const account = readable<Metadata | null>(null, set => {
 
 export const profileRelays = [
   'wss://relay.primal.net',
-  'wss://relay.nostr.band',
-  'wss://purplepag.es'
+  'wss://purplepag.es',
+  'wss://yabu.me',
+  'wss://relay.nostr.wirednet.jp'
 ]
 
 export const relayListRelays = [
@@ -146,7 +231,7 @@ export const defaultRelays = [
 export async function publish(
   unsignedEvent: EventTemplate,
   relay: string | string[]
-): Promise<void> {
+): Promise<Event> {
   const event = await signer.signEvent(unsignedEvent)
   const relays = Array.isArray(relay) ? relay : [relay]
   const results = await Promise.allSettled(
@@ -160,32 +245,56 @@ export async function publish(
     const first = results[0] as PromiseRejectedResult | undefined
     throw first ? first.reason : new Error('no relays to publish to')
   }
+  return event
 }
 
-export async function getMetadata(pubkey: string): Promise<Metadata> {
-  const cached = _metadataCache.get(pubkey)
+// profiles are fetched from `relays` when given — in a NIP-29 chat that
+// must be the group's own relay only, because spraying member pubkeys
+// across public relays leaks who is in the group
+export async function getMetadata(
+  pubkey: string,
+  relays?: string[]
+): Promise<Metadata> {
+  const sources = relays && relays.length ? relays : profileRelays
+  const cacheKey = `${sources.join(',')}|${pubkey}`
+  const cached = _metadataCache.get(cacheKey)
   if (cached) return cached
 
   const fetch = pool
-    .get(profileRelays, {kinds: [0], authors: [pubkey]})
-    .catch(() => null)
-    .then(event => {
-      if (event) {
+    .querySync(sources, {kinds: [0], authors: [pubkey]})
+    .catch(() => [] as Event[])
+    .then(events => {
+      // relays can hold different versions of the profile — a private
+      // team relay may have a newer one with a display name but no
+      // picture. merge field-wise: for each field the newest non-empty
+      // value wins, so a partial profile doesn't erase the rest
+      events.sort((a, b) => b.created_at - a.created_at)
+      const merged: Record<string, unknown> = {}
+      const pictures: string[] = []
+      for (const event of events) {
         try {
-          return {
-            pubkey,
-            nip05valid: false,
-            groups: [],
-            writeRelays: [],
-            ...JSON.parse(event.content)
+          const content = JSON.parse(event.content)
+          for (const [k, v] of Object.entries(content)) {
+            if (v === '' || v === null || v === undefined) continue
+            if (k === 'picture' && typeof v === 'string' && !pictures.includes(v)) {
+              pictures.push(v)
+            }
+            if (!(k in merged)) merged[k] = v
           }
         } catch (err) {
-          /* broken profile content, use the fallback below */
+          /* broken profile content, try the next one */
         }
       }
-      return {pubkey, nip05valid: false, groups: [], writeRelays: []}
+      return {
+        pubkey,
+        nip05valid: false,
+        groups: [],
+        writeRelays: [],
+        ...merged,
+        pictures
+      } as Metadata
     })
-  _metadataCache.set(pubkey, fetch)
+  _metadataCache.set(cacheKey, fetch)
   return fetch
 }
 
@@ -215,11 +324,252 @@ export async function getWriteRelays(
   }
 }
 
+const _relayAuths = new Map<string, Promise<string>>()
+
+// sign a NIP-42 AUTH for this relay exactly once, no matter how many
+// subscriptions hit auth-required at the same time (e.g. the chat and the
+// sidebar group list on a deep link) — concurrent AUTHs race on the same
+// challenge and the loser fails permanently
+export function authRelay(relay: AbstractRelay): Promise<string> {
+  // keyed by challenge, not just url: a reconnected websocket brings a
+  // fresh challenge and needs a fresh AUTH — a cached resolved promise
+  // from the old connection would leave the new one unauthenticated
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const key = `${relay.url}|${(relay as any).challenge ?? ''}`
+  let p = _relayAuths.get(key)
+  if (!p) {
+    p = relay.auth(evt => signer.signEvent(evt) as Promise<VerifiedEvent>)
+    p.catch(() => {
+      // a failed attempt must not poison future retries
+      _relayAuths.delete(key)
+    })
+    _relayAuths.set(key, p)
+  }
+  return p
+}
+
+// like nostr-tools' subscribeRelayGroups, but handles NIP-42 auth-required
+// relays (e.g. private team relays) by authenticating with the user's
+// signer and retrying, doesn't depend on a CORS-enabled NIP-11 endpoint,
+// and also reports each group's member list (kind 39002) so callers can
+// show membership state
+export function subscribeRelayGroupsWithAuth(
+  url: string,
+  callbacks: {
+    ongroups: (groups: Group[], memberships: Record<string, string[]>) => void
+    onerror: (err: Error) => void
+  }
+): () => void {
+  let closed = false
+  let sub: Subscription | undefined
+  let authAttempts = 0
+  let closeRetries = 0
+
+  const fail = (err: unknown) => {
+    if (closed) return
+    callbacks.onerror(err instanceof Error ? err : new Error(String(err)))
+  }
+
+  let membersSub: Subscription | undefined
+
+  const start = async () => {
+    try {
+      const relay = await pool.ensureRelay(normalizeURL(url))
+      if (closed) return
+      const groups: Group[] = []
+      const memberships: Record<string, string[]> = {}
+      let groupsEosed = false
+      const emit = () => {
+        if (groupsEosed) callbacks.ongroups([...groups], {...memberships})
+      }
+      const handleGroup = (event: Event) => {
+        const g = parseGroup(event, relay.url)
+        // replaceable events may arrive again with updates
+        const idx = groups.findIndex(x => x.id === g.id)
+        if (idx === -1) groups.push(g)
+        else groups[idx] = g
+      }
+      const handleMembers = (event: Event) => {
+        const d = event.tags.find(t => t[0] === 'd')?.[1]
+        if (d) memberships[d] = parseMembers(event).map(m => m.pubkey)
+      }
+
+      // member lists are strictly best-effort decoration: they only start
+      // after the groups subscription succeeded, on their own subscription,
+      // so a relay that dislikes this query can never take down the list
+      const startMembers = () => {
+        if (closed) return
+        if (membersSub) membersSub.close()
+        try {
+          membersSub = relay.subscribe([{kinds: [39002], limit: 100}], {
+            onevent(event) {
+              handleMembers(event)
+              emit()
+            },
+            oneose: emit,
+            onclose() {
+              /* membership display is best-effort */
+            }
+          })
+        } catch (err) {
+          console.warn('failed to subscribe to member lists', err)
+        }
+      }
+
+      sub = relay.subscribe([{kinds: [39000], limit: 50}], {
+        onevent: handleGroup,
+        oneose() {
+          groupsEosed = true
+          closeRetries = 0
+          emit()
+          sub!.onevent = event => {
+            handleGroup(event)
+            emit()
+          }
+          startMembers()
+        },
+        onclose(reason) {
+          if (closed) return
+          if (
+            !reason.includes('auth-required') &&
+            !reason.includes('restricted')
+          ) {
+            // dropped idle websocket or a relay that closes subscriptions
+            // on its own — resubscribe with backoff so the list stays live
+            if (closeRetries < 6) {
+              closeRetries++
+              setTimeout(
+                () => {
+                  if (!closed) start()
+                },
+                Math.min(2000 * closeRetries, 15000)
+              )
+            }
+            return
+          }
+          if (reason.includes('auth-required') && authAttempts < 3) {
+            authAttempts++
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            if (!(window as any).nostr) {
+              fail(
+                new Error(
+                  'this relay requires authentication — please log in first'
+                )
+              )
+              return
+            }
+            // the relay may still be registering our AUTH when the retry
+            // arrives, so back off a little more on each attempt
+            authRelay(relay)
+              .then(
+                () => new Promise(r => setTimeout(r, 300 * authAttempts))
+              )
+              .then(() => start())
+              .catch(fail)
+          } else if (
+            reason.includes('auth-required') ||
+            reason.includes('restricted')
+          ) {
+            fail(new Error(reason))
+          }
+        }
+      })
+    } catch (err) {
+      fail(err)
+    }
+  }
+  start()
+
+  return () => {
+    closed = true
+    if (sub) sub.close()
+    if (membersSub) membersSub.close()
+  }
+}
+
+// read a group's kind:39000 metadata, authenticating when the relay asks
+// for it — private team relays reject an anonymous read, which used to
+// leave the sidebar showing the raw group id instead of its name
+export function fetchGroupMetadata(
+  url: string,
+  id: string,
+  timeoutMs = 8000
+): Promise<ChatGroup | null> {
+  return new Promise(resolve => {
+    let settled = false
+    let authAttempted = false
+    const finish = (group: ChatGroup | null) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve(group)
+    }
+    const timer = setTimeout(() => finish(null), timeoutMs)
+
+    // a closed subscription still runs nostr-tools' eose timer, which would
+    // otherwise answer "no metadata" while the auth retry is in flight
+    let attempt = 0
+
+    pool
+      .ensureRelay(normalizeURL(url))
+      .then(relay => {
+        const start = () => {
+          if (settled) return
+          const mine = ++attempt
+          const stale = () => settled || mine !== attempt
+          let found: ChatGroup | null = null
+          let participants: string[] = []
+          const sub = relay.subscribe(
+            [
+              {kinds: [39000], '#d': [id]},
+              // Buzz surfaces DMs as groups that are all named "DM"; the
+              // member list is the only thing telling them apart
+              {kinds: [39002], '#d': [id]}
+            ],
+            {
+            onevent(event) {
+              if (stale()) return
+              if (event.kind === 39002) {
+                participants = parseMembers(event).map(m => m.pubkey)
+                if (found) found.participants = participants
+                return
+              }
+              found = parseGroup(event, relay.url)
+              if (participants.length) found.participants = participants
+            },
+            oneose() {
+              if (stale()) return
+              sub.close()
+              finish(found)
+            },
+            onclose(reason) {
+              if (stale()) return
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const canAuth = !!(window as any).nostr
+              if (reason.includes('auth-required') && !authAttempted && canAuth) {
+                authAttempted = true
+                attempt++ // retire this attempt's pending callbacks
+                authRelay(relay)
+                  .then(start)
+                  .catch(() => finish(null))
+                return
+              }
+              finish(found)
+            }
+            }
+          )
+        }
+        start()
+      })
+      .catch(() => finish(null))
+  })
+}
+
 export function subscribeGroups(
   relays: string[],
   pubkey: string,
   lastGroupsList: Event | undefined,
-  onGroupsUpdated: (_: Group[], __: Event) => void
+  onGroupsUpdated: (_: ChatGroup[], __: Event) => void
 ): () => void {
   let generation = 0
 
@@ -245,31 +595,29 @@ export function subscribeGroups(
   function processGroupsList(groupsList: Event) {
     const thisGeneration = ++generation
     Promise.all(
-      groupsList.tags.map(async (tag): Promise<Group | null> => {
+      groupsList.tags.map(async (tag): Promise<ChatGroup | null> => {
         if (tag[0] !== 'group' || tag.length < 3) return null
 
         // if the group's relay can't be reached right now we still keep the
-        // group in the list, otherwise it would silently vanish
-        const fallback: Group = {
+        // group in the list, otherwise it would silently vanish. the name is
+        // left unset rather than filled with the id so a later lookup (or
+        // the UI's own fallback) can still show a real name
+        const fallback: ChatGroup = {
           id: tag[1],
           relay: tag[2],
-          pubkey: '',
-          name: tag[1]
+          pubkey: ''
         }
         try {
-          const gevent = await pool.get([tag[2]], {
-            kinds: [39000],
-            '#d': [tag[1]]
-          })
-          return gevent ? parseGroup(gevent, tag[2]) : fallback
+          const group = await fetchGroupMetadata(tag[2], tag[1])
+          return group ?? fallback
         } catch (err) {
           return fallback
         }
       })
-    ).then((groups: (Group | null)[]) => {
+    ).then((groups: (ChatGroup | null)[]) => {
       // a newer groups list started processing while we were fetching
       if (thisGeneration !== generation) return
-      onGroupsUpdated(groups.filter(Boolean) as Group[], groupsList)
+      onGroupsUpdated(groups.filter(Boolean) as ChatGroup[], groupsList)
     })
   }
 


### PR DESCRIPTION
Add nostr-login so remote signers, a locally stored key or read-only mode work alongside a NIP-07 extension, and resolve profiles and group names on relays that require authentication, merging profile fields across relays so a partial newer profile no longer hides a complete older one.