### PR TITLE
Rework the chat view with markdown, media and reactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
   "type": "module",
   "dependencies": {
     "debounce": "^1.2.1",
+    "dompurify": "^3.4.13",
+    "markdown-it": "^15.0.0",
     "nostr-login": "^1.7.12",
     "nostr-tools": "2.1.5",
     "nostr-wasm": "0.1.0",

--- a/src/app.html
+++ b/src/app.html
@@ -7,7 +7,7 @@
     %sveltekit.head%
   </head>
 
-  <body class="h-screen p-8">
+  <body class="h-screen bg-slate-50 text-slate-800 antialiased">
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/src/lib/blossom.ts
+++ b/src/lib/blossom.ts
@@ -1,0 +1,92 @@
+import {signer} from './nostr.ts'
+
+// Relays may require Blossom (BUD-01/BUD-11) authorization to read media,
+// which browsers cannot attach to a plain <img src>. Fetching the bytes
+// with the header and handing the <img> a blob: URL is the browser-side
+// equivalent of the localhost proxy the Buzz desktop app uses.
+
+// Ten minutes, the same lifetime Buzz uses: long enough that a message
+// full of images needs a single signature, short enough to stay well
+// inside the relay's freshness window.
+const AUTH_TTL_SECS = 600
+
+type CachedAuth = {header: string; expires: number}
+
+const authByHost = new Map<string, Promise<CachedAuth>>()
+const blobByUrl = new Map<string, Promise<string>>()
+
+function base64url(s: string): string {
+  const bytes = new TextEncoder().encode(s)
+  let bin = ''
+  for (const b of bytes) bin += String.fromCharCode(b)
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+async function mintAuth(host: string): Promise<CachedAuth> {
+  const now = Math.round(Date.now() / 1000)
+  const expiration = now + AUTH_TTL_SECS
+  // server-scoped (a "server" tag and no "x" tag) so one signature covers
+  // every blob on this host; the relay still checks membership for the
+  // signing pubkey, and the header only ever goes to that same host
+  const event = await signer.signEvent({
+    kind: 24242,
+    content: 'Get media',
+    created_at: now,
+    tags: [
+      ['t', 'get'],
+      ['expiration', String(expiration)],
+      ['server', host]
+    ]
+  })
+  return {
+    header: 'Nostr ' + base64url(JSON.stringify(event)),
+    expires: expiration
+  }
+}
+
+async function authHeaderFor(host: string): Promise<string> {
+  const pending = authByHost.get(host)
+  if (pending) {
+    try {
+      const cached = await pending
+      // renew slightly early so a request can't race the expiry
+      if (cached.expires - 30 > Math.round(Date.now() / 1000)) {
+        return cached.header
+      }
+    } catch (err) {
+      /* fall through and mint a new one */
+    }
+  }
+  const fresh = mintAuth(host)
+  authByHost.set(host, fresh)
+  fresh.catch(() => {
+    if (authByHost.get(host) === fresh) authByHost.delete(host)
+  })
+  return (await fresh).header
+}
+
+// fetch media that needs authorization and return a blob: URL for it
+export function authedMediaUrl(url: string): Promise<string> {
+  const cached = blobByUrl.get(url)
+  if (cached) return cached
+
+  const loading = (async () => {
+    const host = new URL(url).host
+    const res = await fetch(url, {
+      headers: {Authorization: await authHeaderFor(host)}
+    })
+    if (!res.ok) throw new Error(`media ${res.status}`)
+    return URL.createObjectURL(await res.blob())
+  })()
+
+  blobByUrl.set(url, loading)
+  loading.catch(() => {
+    if (blobByUrl.get(url) === loading) blobByUrl.delete(url)
+  })
+  return loading
+}
+
+export function canSignMediaAuth(): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return typeof (window as any).nostr !== 'undefined'
+}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,119 @@
+import MarkdownIt from 'markdown-it'
+import DOMPurify from 'dompurify'
+
+// message bodies are markdown, matching what other NIP-29 clients (Buzz)
+// publish and render: GFM-ish with hard line breaks, since chat messages
+// are written with the enter key rather than blank lines
+const md = new MarkdownIt({
+  html: false, // never trust raw HTML from a relay
+  linkify: true, // bare URLs become links
+  breaks: true, // a single newline is a line break
+  typographer: false
+})
+
+export type ImageMeta = {
+  url: string
+  alt?: string
+  dim?: string // "<width>x<height>", used to reserve space before load
+  thumb?: string // relay-generated thumbnail, cheaper for the inline view
+}
+
+// NIP-92 "imeta" tags carry optional metadata about the media referenced
+// in the body; nothing depends on them, they only improve rendering
+export function parseImetaTags(tags: string[][]): Map<string, ImageMeta> {
+  const map = new Map<string, ImageMeta>()
+  for (const tag of tags) {
+    if (tag[0] !== 'imeta') continue
+    const entry: Partial<ImageMeta> = {}
+    for (const part of tag.slice(1)) {
+      const sp = part.indexOf(' ')
+      if (sp === -1) continue
+      const key = part.slice(0, sp)
+      const val = part.slice(sp + 1)
+      if (key === 'url') entry.url = val
+      else if (key === 'alt') entry.alt = val
+      else if (key === 'dim') entry.dim = val
+      else if (key === 'thumb') entry.thumb = val
+    }
+    if (entry.url) map.set(entry.url, entry as ImageMeta)
+  }
+  return map
+}
+
+const defaultLinkOpen =
+  md.renderer.rules.link_open ||
+  ((tokens, idx, options, _env, self) => self.renderToken(tokens, idx, options))
+
+md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+  tokens[idx].attrSet('target', '_blank')
+  tokens[idx].attrSet('rel', 'noopener noreferrer')
+  return defaultLinkOpen(tokens, idx, options, env, self)
+}
+
+md.renderer.rules.image = (tokens, idx, _options, env) => {
+  const token = tokens[idx]
+  const src = String(token.attrGet('src') || '')
+  const meta: ImageMeta | undefined = (
+    env as {imeta?: Map<string, ImageMeta>} | undefined
+  )?.imeta?.get(src)
+  const alt = String(token.content || meta?.alt || '')
+  // reserving the aspect ratio keeps messages from jumping around while
+  // images load, the same reason Buzz stores "dim" in imeta
+  let style = ''
+  const dim = meta?.dim?.match(/^(\d+)x(\d+)$/)
+  if (dim) style = ` style="aspect-ratio:${dim[1]}/${dim[2]}"`
+  // prefer the relay's thumbnail for the inline view; the full blob is
+  // only fetched when the image is opened
+  const display = String(meta?.thumb || src)
+  const escapedSrc = md.utils.escapeHtml(src)
+  const escapedDisplay = md.utils.escapeHtml(display)
+  const escapedAlt = md.utils.escapeHtml(alt)
+  return (
+    `<a href="${escapedSrc}" target="_blank" rel="noopener noreferrer" class="md-image-link">` +
+    `<img src="${escapedDisplay}" data-src="${escapedDisplay}" alt="${escapedAlt}" loading="lazy"${style}>` +
+    `</a>`
+  )
+}
+
+let purifierReady = false
+function ensurePurifier() {
+  if (purifierReady) return
+  purifierReady = true
+  // links are rendered with target=_blank above; make sure nothing can
+  // strip the rel that protects the opener
+  DOMPurify.addHook('afterSanitizeAttributes', node => {
+    if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+      node.setAttribute('rel', 'noopener noreferrer')
+    }
+  })
+}
+
+const ALLOWED_TAGS = [
+  'p', 'br', 'hr', 'em', 'strong', 's', 'del', 'blockquote',
+  'ul', 'ol', 'li', 'code', 'pre', 'a', 'img',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'table', 'thead', 'tbody', 'tr', 'th', 'td'
+]
+
+const ALLOWED_ATTR = [
+  'href', 'title', 'target', 'rel',
+  'src', 'alt', 'loading', 'style', 'class'
+]
+
+// render a message body to sanitized HTML
+export function renderMarkdown(
+  content: string,
+  imeta?: Map<string, ImageMeta>
+): string {
+  ensurePurifier()
+  const html = md.render(content, {imeta})
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS,
+    ALLOWED_ATTR,
+    // data: and blob: URLs in messages are more likely abuse than content
+    ALLOWED_URI_REGEXP: /^(?:https?:|mailto:|nostr:|#)/i,
+    // the regexp above is also applied to attributes that aren't URIs
+    // unless they are declared safe, which would drop these two
+    ADD_URI_SAFE_ATTR: ['target', 'loading']
+  })
+}

--- a/src/lib/mediaAction.ts
+++ b/src/lib/mediaAction.ts
@@ -1,0 +1,108 @@
+import {authedMediaUrl, canSignMediaAuth} from './blossom.ts'
+
+// Images in message bodies are plain <img> tags produced by the markdown
+// renderer. Relays that gate media behind Blossom authorization answer
+// those requests with 401, and a browser cannot attach the header to an
+// <img src>. This action watches for such failures and re-fetches the
+// bytes with authorization, handing the element a blob: URL instead.
+export type MediaParams = {
+  // re-rendered body, only used so the action's update() fires
+  body: string
+  // host of the relay this chat is on; authorization is minted for it
+  // alone, so a broken third-party image can never trigger a signature
+  host: string
+}
+
+export function enhanceMedia(node: HTMLElement, params: MediaParams) {
+  // images whose inline view needed authorization: their full-size view
+  // needs it as well, so the anchor click has to be intercepted
+  const authed = new WeakSet<HTMLImageElement>()
+
+  function isRelayMedia(url: string): boolean {
+    if (!params.host) return false
+    try {
+      return new URL(url, location.href).host === params.host
+    } catch (err) {
+      return false
+    }
+  }
+
+  async function loadAuthed(img: HTMLImageElement) {
+    const src = img.dataset.src
+    if (!src || img.dataset.mediaState) return
+    if (!isRelayMedia(src)) {
+      img.dataset.mediaState = 'external'
+      return
+    }
+    if (!canSignMediaAuth()) {
+      img.dataset.mediaState = 'unavailable'
+      return
+    }
+    img.dataset.mediaState = 'loading'
+    try {
+      img.src = await authedMediaUrl(src)
+      img.dataset.mediaState = 'authed'
+      authed.add(img)
+    } catch (err) {
+      console.warn('failed to load media', src, err)
+      img.dataset.mediaState = 'failed'
+      // leave the broken image; the surrounding link still works
+    }
+  }
+
+  function onError(ev: Event) {
+    const img = ev.target
+    if (img instanceof HTMLImageElement && img.dataset.src) loadAuthed(img)
+  }
+
+  async function onClick(ev: MouseEvent) {
+    const target = ev.target
+    if (!(target instanceof HTMLImageElement)) return
+    if (!authed.has(target)) return
+    const anchor = target.closest('a')
+    const full = anchor?.getAttribute('href')
+    if (!full) return
+    // a new tab cannot send the authorization header either, so resolve
+    // the full-size blob here and open that
+    ev.preventDefault()
+    try {
+      window.open(await authedMediaUrl(full), '_blank', 'noopener')
+    } catch (err) {
+      console.warn('failed to open media', full, err)
+    }
+  }
+
+  // the error event does not bubble, so it has to be captured
+  node.addEventListener('error', onError, true)
+  node.addEventListener('click', onClick)
+
+  function scan() {
+    for (const img of node.querySelectorAll('img[data-src]')) {
+      if (!(img instanceof HTMLImageElement)) continue
+      // an element whose src is left to this action (so a re-render can't
+      // reset an authorized blob: URL back to the bare, 401-ing one)
+      if (!img.getAttribute('src')) {
+        img.src = img.dataset.src as string
+        continue
+      }
+      // an image that already failed before this action ran (or was
+      // restored from cache as broken) never fires another error event
+      if (img.complete && img.naturalWidth === 0) {
+        loadAuthed(img)
+      }
+    }
+  }
+  scan()
+
+  return {
+    update(next: MediaParams) {
+      params = next
+      // the body was re-rendered: new <img> elements need the same check
+      scan()
+    },
+    destroy() {
+      node.removeEventListener('error', onError, true)
+      node.removeEventListener('click', onClick)
+    }
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,6 +8,40 @@ export function humanDate(created_at: number): string {
   return ago(new Date(d))
 }
 
+export type MessageSegment = {
+  type: 'text' | 'code'
+  content: string
+  lang?: string
+}
+
+// split a message into plain-text and ```fenced code``` segments; unclosed
+// fences stay plain text. rendering keeps using svelte text interpolation,
+// so nothing here needs escaping
+export function splitCodeBlocks(src: string): MessageSegment[] {
+  const segments: MessageSegment[] = []
+  const re = /```([^\n`]*)\n([\s\S]*?)\n?```/g
+
+  let last = 0
+  let m: RegExpExecArray | null
+  while ((m = re.exec(src)) !== null) {
+    let text = src.slice(last, m.index)
+    // drop the newline separating text from the fence, the block spacing
+    // already provides it visually
+    text = text.replace(/\n$/, '')
+    if (last > 0) text = text.replace(/^\n/, '')
+    if (text !== '') segments.push({type: 'text', content: text})
+
+    segments.push({type: 'code', content: m[2], lang: m[1].trim() || undefined})
+    last = re.lastIndex
+  }
+
+  let rest = src.slice(last)
+  if (last > 0) rest = rest.replace(/^\n/, '')
+  if (rest !== '') segments.push({type: 'text', content: rest})
+
+  return segments
+}
+
 export const toastState = writable<ToastState | null>(null)
 
 export function showToast(state: ToastState, timeout: number = 4000) {

--- a/src/pages/ChatPage.svelte
+++ b/src/pages/ChatPage.svelte
@@ -1,3 +1,12 @@
+<script lang="ts" context="module">
+  import type {Event as CachedEvent} from 'nostr-tools/wasm'
+
+  // per-group message cache so switching between groups shows the last
+  // known messages instantly while the subscription refetches in the
+  // background; module-scoped so it survives page component re-creation
+  const messageCache = new Map<string, CachedEvent[]>()
+</script>
+
 <script lang="ts">
   import {afterUpdate, onMount} from 'svelte'
   import {debounce} from 'debounce'
@@ -11,9 +20,17 @@
     type Member
   } from 'nostr-tools/nip29'
 
-  import {account, signer} from '../lib/nostr.ts'
-  import {pool, publish} from '../lib/nostr.ts'
+  import {account} from '../lib/nostr.ts'
+  import {
+    pool,
+    publish,
+    authRelay,
+    profileRelays,
+    subscribeRelayGroupsWithAuth
+  } from '../lib/nostr.ts'
   import {showToast, humanDate} from '../lib/utils.ts'
+  import {renderMarkdown, parseImetaTags} from '../lib/markdown.ts'
+  import {enhanceMedia} from '../lib/mediaAction.ts'
   import UserLabel from '../components/UserLabel.svelte'
   import Header from '../components/Header.svelte'
   import MemberLabel from '../components/MemberLabel.svelte'
@@ -23,6 +40,13 @@
   export let id: string
 
   let messages: Event[] = []
+  // NIP-25 kind-7 reaction events, keyed by the reacted message's id
+  let reactions: Record<string, Event[]> = {}
+  // reactions from other clients (Buzz) only carry the "e" tag of the
+  // message they belong to — no NIP-29 "h" tag — so they have to be
+  // subscribed by message id rather than by group
+  let reactionSub: Subscription | undefined
+  let reactionIdsKey = ''
   let text = localStorage.getItem('text') || ''
   let isSending = false
   let group: Group | null = null
@@ -31,15 +55,48 @@
   let info: {pubkey: string; name: string; description: string; icon: string}
   let relay: AbstractRelay
   let sub: Subscription
+  let liveSub: Subscription | undefined
+  let pollTimer: ReturnType<typeof setInterval> | undefined
   let eoseHappened = false
+  let relayChannels: Group[] = []
+  let relayMemberships: Record<string, string[]> = {}
+  let relayChannelsHost = ''
+  let cancelRelayChannels: (() => void) | undefined
 
-  $: groupRawName = relay ? `${new URL(relay.url).host}'${group?.id}` : ''
+  // newest message created_at per group on this relay, and the newest
+  // created_at the user has seen per group — the sidebar shows an
+  // unread dot when activity is newer than the last read position
+  let groupActivity: Record<string, number> = {}
+  let lastReads: Record<string, number> = {}
+  let activitySub: Subscription | undefined
+  let activityIdsKey = ''
+
+  // profiles of chat participants are looked up on this relay first-hand,
+  // plus the public profile relays for users who only publish kind 0 there
+  $: chatRelays = relay ? [relay.url, ...profileRelays] : []
+  // media hosted by the chat relay itself may need Blossom auth
+  $: mediaHost = relay ? new URL(relay.url).host : ''
   $: isMember = !!members.find(m => m.pubkey === $account?.pubkey)
   $: isAdmin = !!admins.find(m => m.pubkey === $account?.pubkey)
 
+  // while a group switch reloads `group`/`members`, fall back to the
+  // relay-wide lists (kept across switches on the same relay) so the
+  // sidebar's "add this group to list?" button doesn't blink out and
+  // shift the sections below it
+  $: sidebarGroup = group ?? relayChannels.find(c => c.id === id) ?? null
+  $: sidebarIsMember =
+    !!$account &&
+    (isMember || !!relayMemberships[id]?.includes($account.pubkey))
+
   const updateMessages = debounce(() => {
+    // stored events can arrive after eose fired: nostr-tools gives up
+    // waiting for EOSE after 4.4s and a slow relay answers the REQ later,
+    // so events landing here are not necessarily in chronological order
+    messages.sort((a, b) => a.created_at - b.created_at)
     messages = messages
     scrollToEnd()
+    markRead()
+    refreshReactions()
   }, 300)
 
   const saveToLocalStorage = debounce(() => {
@@ -56,34 +113,388 @@
     }
   }
 
+  function cacheCurrentMessages() {
+    if (current && messages.length) {
+      messageCache.set(`${current.host}|${current.id}`, messages)
+    }
+  }
+
+  function lastReadKey(h: string, groupId: string): string {
+    return `lastRead:${h}'${groupId}`
+  }
+
+  function markRead() {
+    if (!current || !messages.length) return
+    const t = messages[messages.length - 1].created_at
+    if ((lastReads[current.id] || 0) >= t) return
+    lastReads[current.id] = t
+    lastReads = lastReads
+    localStorage.setItem(lastReadKey(current.host, current.id), String(t))
+  }
+
+  function noteActivity(event: Event) {
+    const h = event.tags.find(t => t[0] === 'h')?.[1]
+    if (!h) return
+    if ((groupActivity[h] || 0) < event.created_at) {
+      groupActivity[h] = event.created_at
+      groupActivity = groupActivity
+    }
+  }
+
+  // one lightweight subscription covering every public group of the
+  // relay keeps the sidebar's unread dots fresh; re-created only when
+  // the set of groups actually changes
+  function ensureActivitySub(ids: string[]) {
+    const key = ids.slice().sort().join(',')
+    if (key === activityIdsKey && activitySub) return
+    activityIdsKey = key
+    if (activitySub) {
+      activitySub.close()
+      activitySub = undefined
+    }
+    if (!ids.length || !relay) return
+
+    for (const groupId of ids) {
+      if (!(groupId in lastReads)) {
+        const stored = localStorage.getItem(lastReadKey(relayChannelsHost, groupId))
+        if (stored) lastReads[groupId] = Number(stored)
+      }
+    }
+    lastReads = lastReads
+
+    // initial snapshot: the newest events across all groups tell us
+    // which ones have activity beyond the stored read positions
+    pool
+      .querySync([relay.url], {kinds: [9, 10, 11, 12], '#h': ids, limit: 100})
+      .then(events => {
+        for (const e of events) noteActivity(e)
+      })
+      .catch(err => {
+        console.warn('failed to load group activity', err)
+      })
+
+    activitySub = relay.subscribe(
+      [
+        {
+          kinds: [9, 10, 11, 12],
+          '#h': ids,
+          since: Math.round(Date.now() / 1000) - 10
+        }
+      ],
+      {
+        onevent: noteActivity,
+        onclose() {
+          /* unread dots are best-effort */
+        }
+      }
+    )
+  }
+
   onMount(() => {
-    return unloadChat
+    return () => {
+      cacheCurrentMessages()
+      unloadChat()
+      if (cancelRelayChannels) cancelRelayChannels()
+      if (activitySub) activitySub.close()
+    }
   })
 
   let current: {host: string; id: string} | null
   let authAttempted = false
+  // generation guard: closing a subscription on purpose (navigation,
+  // auth retry) must not be mistaken for a dropped connection
+  let chatGeneration = 0
+  let reconnectAttempts = 0
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined
   afterUpdate(() => {
     if (current && current.host === host && current.id === id) return
+    cacheCurrentMessages()
     current = {host, id}
-    authAttempted = false
+    reconnectAttempts = 0
     unloadChat()
     loadChat()
   })
 
   function unloadChat() {
+    chatGeneration++
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = undefined
+    }
+    if (pollTimer) {
+      clearInterval(pollTimer)
+      pollTimer = undefined
+    }
+    if (liveSub) {
+      liveSub.close()
+      liveSub = undefined
+    }
+    if (reactionSub) {
+      reactionSub.close()
+      reactionSub = undefined
+    }
+    reactionIdsKey = ''
     if (sub) sub.close()
     eoseHappened = false
     messages = []
+    reactions = {}
     group = null
     admins = []
     members = []
   }
 
+  // (re)subscribe to the reactions of the messages currently loaded. the
+  // subscription stays open so live reactions arrive as well; it is only
+  // rebuilt when the set of messages actually changed
+  const refreshReactions = debounce(() => {
+    if (!relay || !messages.length) return
+    // newest messages first: those are the ones on screen, and a relay
+    // that caps tag values will keep the most useful ones
+    const ids = messages.slice(-500).map(m => m.id)
+    const key = `${ids.length}:${ids[0]}:${ids[ids.length - 1]}`
+    if (key === reactionIdsKey && reactionSub) return
+    reactionIdsKey = key
+
+    const chunks: string[][] = []
+    for (let i = 0; i < ids.length; i += 250) chunks.push(ids.slice(i, i + 250))
+
+    const previous = reactionSub
+    try {
+      reactionSub = relay.subscribe(
+        chunks.map(chunk => ({kinds: [7], '#e': chunk})),
+        {
+          onevent(event) {
+            if (addReactionEvent(event)) reactions = reactions
+          },
+          oneose() {
+            reactions = reactions
+          },
+          onclose() {
+            /* reactions are decoration; the next refresh retries */
+          }
+        }
+      )
+    } catch (err) {
+      console.warn('failed to subscribe to reactions', err)
+      reactionIdsKey = ''
+    }
+    if (previous) previous.close()
+  }, 500)
+
+  function pushMessage(event: Event): boolean {
+    if (messages.some(m => m.id === event.id)) return false
+    messages.push(event)
+    return true
+  }
+
+  // per NIP-25 the reacted event is the last "e" tag
+  function reactionTarget(event: Event): string | undefined {
+    for (let i = event.tags.length - 1; i >= 0; i--) {
+      const tag = event.tags[i]
+      if (
+        tag[0] === 'e' &&
+        typeof tag[1] === 'string' &&
+        tag[1].length === 64
+      ) {
+        return tag[1]
+      }
+    }
+    return undefined
+  }
+
+  function addReactionEvent(event: Event): boolean {
+    const target = reactionTarget(event)
+    if (!target) return false
+    const list = reactions[target] || []
+    if (list.some(r => r.id === event.id)) return false
+    reactions[target] = [...list, event]
+    reactions = reactions
+    return true
+  }
+
+  function removeReactionsLocally(ids: string[]) {
+    let changed = false
+    for (const key of Object.keys(reactions)) {
+      // the reacted message was deleted: drop its reactions wholesale
+      if (ids.includes(key)) {
+        delete reactions[key]
+        changed = true
+        continue
+      }
+      // a reaction itself was deleted (un-react)
+      const filtered = reactions[key].filter(r => !ids.includes(r.id))
+      if (filtered.length !== reactions[key].length) {
+        if (filtered.length) reactions[key] = filtered
+        else delete reactions[key]
+        changed = true
+      }
+    }
+    if (changed) reactions = reactions
+  }
+
+  type ReactionChip = {
+    key: string
+    text?: string
+    url?: string
+    count: number
+    mine: Event | null
+    sample: Event
+  }
+
+  // how a single kind-7 content is displayed: '+'/'' mean like, '-'
+  // dislike, and ':shortcode:' is a NIP-30 custom emoji whose image URL
+  // sits in the event's own 'emoji' tag
+  function reactionDisplay(r: Event): {key: string; text?: string; url?: string} {
+    const c = r.content.trim()
+    if (c === '+' || c === '') return {key: '+', text: '👍'}
+    if (c === '-') return {key: '-', text: '👎'}
+    const m = c.match(/^:([a-zA-Z0-9_+-]+):$/)
+    if (m) {
+      const url = r.tags.find(t => t[0] === 'emoji' && t[1] === m[1])?.[2]
+      if (url) return {key: c, url}
+    }
+    return {key: c, text: c}
+  }
+
+  function aggregateReactions(list: Event[] | undefined): ReactionChip[] {
+    if (!list || !list.length) return []
+    const chips = new Map<string, ReactionChip & {pubkeys: string[]}>()
+    for (const r of list) {
+      const d = reactionDisplay(r)
+      let chip = chips.get(d.key)
+      if (!chip) {
+        chip = {...d, count: 0, mine: null, sample: r, pubkeys: []}
+        chips.set(d.key, chip)
+      }
+      // count each user once per emoji even if a relay kept several
+      if (!chip.pubkeys.includes(r.pubkey)) {
+        chip.pubkeys.push(r.pubkey)
+        chip.count++
+      }
+      if (r.pubkey === $account?.pubkey) chip.mine = r
+    }
+    return [...chips.values()]
+  }
+
+  // a chat message is a reply when it references another event via a
+  // "q" (quote) tag or a non-mention "e" tag
+  function replyRefOf(message: Event): string | undefined {
+    const tag = message.tags.find(
+      t =>
+        (t[0] === 'q' || (t[0] === 'e' && t[3] !== 'mention')) &&
+        typeof t[1] === 'string' &&
+        t[1].length === 64
+    )
+    return tag?.[1]
+  }
+
+  function scrollToMessage(id: string) {
+    document
+      .getElementById(`evt-${id.slice(-6)}`)
+      ?.scrollIntoView({behavior: 'smooth', block: 'center'})
+  }
+
+  // safety net for relays that never stream live events over an open
+  // subscription: periodically fetch anything newer than what we have
+  async function pollRecent() {
+    if (!current || !relay) return
+    try {
+      const last = messages.length
+        ? messages[messages.length - 1].created_at
+        : Math.round(Date.now() / 1000)
+      const recent = await pool.querySync([relay.url], {
+        kinds: [9, 10, 11, 12],
+        '#h': [current.id],
+        since: last - 300,
+        limit: 100
+      })
+      let added = 0
+      for (const evt of recent) {
+        if (pushMessage(evt)) added++
+      }
+      if (added) {
+        // if this ever fires, the relay is not streaming live events to
+        // our open subscription — keep the poller; if it stays quiet the
+        // poller can be removed
+        console.warn(`poller found ${added} message(s) the live stream missed`)
+        messages.sort((a, b) => a.created_at - b.created_at)
+        messages = messages
+        scrollToEnd()
+        markRead()
+      }
+    } catch (err) {
+      console.warn('failed to poll recent messages', err)
+    }
+  }
+
+  // proxies in front of relays (e.g. cloudflare) drop idle websockets,
+  // and some relays close subscriptions on their own — without a
+  // reconnect the chat silently stops receiving new events
+  function scheduleReconnect(reason: string) {
+    if (reconnectTimer) return
+    const delay = Math.min(1000 * 2 ** reconnectAttempts, 15000)
+    reconnectAttempts++
+    console.warn(
+      `chat subscription closed (${reason}) — reconnecting in ${delay}ms`
+    )
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = undefined
+      unloadChat()
+      loadChat()
+    }, delay)
+  }
+
   async function loadChat() {
     if (!current) return
+    const gen = ++chatGeneration
+    authAttempted = false
+
+    // show the last known messages of this group instantly; the
+    // subscription below refetches and reconciles in the background
+    const cached = messageCache.get(`${current.host}|${current.id}`)
+    if (cached && !messages.length) {
+      messages = [...cached]
+      scrollToEnd()
+      markRead()
+    }
+
+    // ids seen from the current subscription, to weed out cached
+    // messages that were deleted while we were not subscribed
+    const freshIds = new Set<string>()
+    let minFreshCreatedAt = Infinity
 
     try {
       relay = await pool.ensureRelay(current.host)
+
+      // keep a list of the relay's public groups in the sidebar; only
+      // resubscribe when we move to a different relay
+      if (!cancelRelayChannels || relayChannelsHost !== current.host) {
+        if (cancelRelayChannels) cancelRelayChannels()
+        relayChannelsHost = current.host
+        relayChannels = []
+        relayMemberships = {}
+        if (activitySub) {
+          activitySub.close()
+          activitySub = undefined
+        }
+        activityIdsKey = ''
+        groupActivity = {}
+        lastReads = {}
+        cancelRelayChannels = subscribeRelayGroupsWithAuth(current.host, {
+          ongroups(groups: Group[], m: Record<string, string[]>) {
+            // a re-subscription racing with the relay's auth handling can
+            // deliver an empty snapshot after a good one — never let that
+            // blank out a list the user is already looking at
+            if (groups.length || !relayChannels.length) relayChannels = groups
+            if (Object.keys(m).length || !Object.keys(relayMemberships).length)
+              relayMemberships = m
+            ensureActivitySub(relayChannels.map(g => g.id))
+          },
+          onerror(err: Error) {
+            console.warn('failed to load relay groups', err)
+          }
+        })
+      }
 
       // NIP-11 information is nice to have, but plenty of relays don't
       // serve it (or lack CORS headers) — never let it block the chat
@@ -100,7 +511,12 @@
 
       sub = relay.subscribe(
         [
-          {kinds: [9], '#h': [current.id], limit: 700},
+          // 9 = chat message, 10 = chat reply, 11/12 = thread post/reply —
+          // bots and other clients use the reply kinds too
+          {kinds: [9, 10, 11, 12], '#h': [current.id], limit: 700},
+          // reactions get their own filter so they don't eat into the
+          // message limit above
+          {kinds: [7], '#h': [current.id], limit: 700},
           {kinds: [39000, 39001, 39002], '#d': [current.id]},
           {
             kinds: [5, 9005],
@@ -124,43 +540,70 @@
               case 39002:
                 members = parseMembers(event)
                 break
+              case 7:
+                addReactionEvent(event)
+                break
               case 9:
+              case 10:
+              case 11:
+              case 12:
+                freshIds.add(event.id)
+                if (event.created_at < minFreshCreatedAt) {
+                  minFreshCreatedAt = event.created_at
+                }
                 // the subscription can be restarted (e.g. after AUTH), so
                 // the same stored events may arrive again
-                if (!messages.some(m => m.id === event.id)) {
-                  messages.push(event as any)
-                  if (eoseHappened) updateMessages()
+                if (pushMessage(event as any) && eoseHappened) {
+                  updateMessages()
                 }
                 break
               case 9005:
-              case 5:
+              case 5: {
+                const ids: string[] = []
                 for (let i = 0; i < event.tags.length; i++) {
                   let tag = event.tags[i]
                   if (tag.length < 2 || tag[0] !== 'e') continue
-                  let id = tag[1]
-                  let idx = messages.findIndex(m => m.id === id)
+                  ids.push(tag[1])
+                  let idx = messages.findIndex(m => m.id === tag[1])
                   if (idx !== -1) {
                     messages.splice(idx, 1)
                   }
                 }
                 messages = messages
+                // the deleted event may have been a reaction, or a message
+                // that had reactions
+                removeReactionsLocally(ids)
                 break
+              }
             }
           },
           oneose() {
+            // drop cached messages the relay no longer returned inside the
+            // refetched range: they were deleted while we were away (events
+            // older than the fetch window are kept — the 700-limit query
+            // simply doesn't reach them)
+            if (freshIds.size) {
+              messages = messages.filter(
+                m => freshIds.has(m.id) || m.created_at < minFreshCreatedAt
+              )
+            }
             // relays are not required to return stored events in any
             // particular order, so sort instead of blindly reversing
             messages.sort((a, b) => a.created_at - b.created_at)
             messages = messages
             scrollToEnd()
+            markRead()
+            refreshReactions()
             eoseHappened = true
+            if (gen === chatGeneration) reconnectAttempts = 0
           },
           onclose(reason) {
+            // a close we caused ourselves (navigation, auth retry)
+            if (gen !== chatGeneration) return
             console.warn(relay.url, 'relay connection closed', reason)
             if (reason.includes('auth-required') && !authAttempted) {
               authAttempted = true
-              relay
-                .auth(evt => signer.signEvent(evt) as Promise<VerifiedEvent>)
+              authRelay(relay)
                 .then(() => {
                   unloadChat()
                   loadChat()
@@ -169,10 +612,41 @@
                   console.warn('auth failed', err)
                   showToast({type: 'error', text: String(err)})
                 })
+            } else if (!reason.includes('restricted')) {
+              scheduleReconnect(reason)
             }
           }
         }
       )
+
+      // dedicated live stream: no limit, since ~now — some relays treat
+      // limited REQs as one-shot queries and never stream events on them
+      liveSub = relay.subscribe(
+        [
+          {
+            kinds: [7, 9, 10, 11, 12],
+            '#h': [current.id],
+            since: Math.round(Date.now() / 1000) - 10
+          }
+        ],
+        {
+          onevent(event) {
+            if (gen !== chatGeneration) return
+            if (event.kind === 7) {
+              addReactionEvent(event)
+              return
+            }
+            freshIds.add(event.id)
+            if (pushMessage(event as any)) updateMessages()
+          },
+          onclose() {
+            /* the poller below covers us if this stream dies */
+          }
+        }
+      )
+
+      if (pollTimer) clearInterval(pollTimer)
+      pollTimer = setInterval(pollRecent, 15000)
     } catch (err: any) {
       console.warn('failed to load chat', err)
       console.warn(err.stack)
@@ -192,6 +666,10 @@
         },
         relay.url
       )
+      showToast({
+        type: 'success',
+        text: 'join request sent — open groups accept instantly, closed ones need admin approval'
+      })
       isSending = false
     } catch (err: any) {
       console.warn('failed to ask to join', err)
@@ -201,20 +679,41 @@
     }
   }
 
+
+  // NIP-29 anti-fork marker: reference the latest events we've seen so
+  // the relay can verify we're on the same timeline — strict relays may
+  // reject messages without it
+  function previousTag(): string[][] {
+    const ids = messages.slice(-3).map(m => m.id.slice(0, 8))
+    return ids.length ? [['previous', ...ids]] : []
+  }
+
   async function sendMessage() {
     if (isSending || !isMember || !group || !relay) return
     if (text.trim() === '') return
     try {
       isSending = true
-      await publish(
-        {
-          kind: 9,
-          content: text,
-          tags: [['h', group!.id]],
-          created_at: Math.round(Date.now() / 1000)
-        },
-        relay.url
-      )
+      const sent = (await Promise.race([
+        publish(
+          {
+            kind: 9,
+            content: text,
+            tags: [['h', group!.id], ...previousTag()],
+            created_at: Math.round(Date.now() / 1000)
+          },
+          relay.url
+        ),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('send timed out')), 10000)
+        )
+      ])) as Event
+      // show our own message right away — not every relay echoes events
+      // back to the sender's own subscription (deduped by id if it does)
+      if (!messages.some(m => m.id === sent.id)) {
+        messages.push(sent)
+        messages = messages
+        scrollToEnd()
+      }
       text = ''
       saveToLocalStorage()
       isSending = false
@@ -223,6 +722,63 @@
       console.warn(err.stack)
       showToast({type: 'error', text: String(err)})
       isSending = false
+    }
+  }
+
+  async function react(message: Event, content: string, extraTags: string[][] = []) {
+    if (!isMember || !group || !relay) return
+    try {
+      const sent = await publish(
+        {
+          kind: 7,
+          content,
+          tags: [
+            ['h', group.id],
+            ['e', message.id],
+            ['p', message.pubkey],
+            ['k', String(message.kind)],
+            ...extraTags,
+            ...previousTag()
+          ],
+          created_at: Math.round(Date.now() / 1000)
+        },
+        relay.url
+      )
+      // show it right away — not every relay echoes events back
+      addReactionEvent(sent)
+    } catch (err: any) {
+      console.warn('failed to react', err)
+      showToast({type: 'error', text: String(err)})
+    }
+  }
+
+  async function toggleReaction(message: Event, chip: ReactionChip) {
+    if (!isMember || !group || !relay) return
+    if (chip.mine) {
+      // un-react: delete our own reaction event
+      try {
+        await publish(
+          {
+            kind: 5,
+            content: '',
+            tags: [
+              ['h', group.id],
+              ['e', chip.mine.id]
+            ],
+            created_at: Math.round(Date.now() / 1000)
+          },
+          relay.url
+        )
+        removeReactionsLocally([chip.mine.id])
+      } catch (err: any) {
+        console.warn('failed to remove reaction', err)
+        showToast({type: 'error', text: String(err)})
+      }
+    } else {
+      // custom emoji reactions need their 'emoji' tag re-attached so
+      // other clients can resolve the shortcode to its image
+      const emojiTags = chip.sample.tags.filter(t => t[0] === 'emoji')
+      await react(message, chip.sample.content, emojiTags)
     }
   }
 
@@ -242,11 +798,46 @@
           },
           relay.url
         )
+        // reflect the deletion immediately — not every relay echoes the
+        // deletion event back to the sender's own subscription
+        const idx = messages.findIndex(m => m.id === id)
+        if (idx !== -1) {
+          messages.splice(idx, 1)
+          messages = messages
+        }
       } catch (err: any) {
         console.warn('failed to delete', err)
         console.warn(err.stack)
         showToast({type: 'error', text: String(err)})
       }
+    }
+  }
+
+  // group status change (NIP-29 kind 9006): the relay applies the flag
+  // tags and re-broadcasts the 39000 metadata, which updates `group`
+  async function setGroupStatus(priv: boolean, closed: boolean) {
+    if (!group) return
+    try {
+      isSending = true
+      await publish(
+        {
+          kind: 9006,
+          content: '',
+          tags: [
+            ['h', group.id],
+            [priv ? 'private' : 'public'],
+            [closed ? 'closed' : 'open']
+          ],
+          created_at: Math.round(Date.now() / 1000)
+        },
+        relay.url
+      )
+      showToast({type: 'success', text: 'group status updated'})
+    } catch (err: any) {
+      console.warn('failed to update group status', err)
+      showToast({type: 'error', text: String(err)})
+    } finally {
+      isSending = false
     }
   }
 
@@ -293,133 +884,401 @@
   }
 </script>
 
-<div
-  class="h-full grid gap-2"
-  style:grid-template-areas={`
-    "header header header"
-    "groups chat members"
-  `}
-  style:grid-template-rows="fit-content(20%) auto"
-  style:grid-template-columns="fit-content(10%) auto fit-content(10%)"
->
-  <header class="pb-3 h-full bg-white" style:grid-area="header">
+<div class="flex h-screen flex-col overflow-hidden">
+  <header
+    class="shrink-0 border-b border-slate-200 bg-white/90 px-6 py-3 backdrop-blur"
+  >
     <Header />
-    <div class="flex items-center justify-end mt-4">
-      <div class="text-sm">room</div>
-      <div class="text-emerald-600 text-lg mx-4 overflow-hidden text-ellipsis">
-        {group?.name || groupRawName || `${current?.host}'${current?.id}`}
-      </div>
-      <div class="text-xs text-stone-400">
-        {groupRawName}
-      </div>
+    <div class="mt-2 flex min-w-0 items-baseline justify-end gap-2">
+      <span
+        class="truncate text-lg font-semibold text-slate-900"
+        title={id}
+      >
+        #{group?.name || id}
+      </span>
+      <span class="hidden text-xs text-slate-400 sm:inline">on {host}</span>
     </div>
   </header>
-  <aside style:grid-area="groups">
-    <GroupsList current={isMember ? group : null} />
-  </aside>
-  <aside style:grid-area="members">
-    <div class="pl-4">
-      <h3 class="text-lg text-emerald-600">admins</h3>
-      {#each admins as admin}
-        <MemberLabel member={admin} />
-      {/each}
-      <h3 class="pt-2 text-lg text-emerald-600">members</h3>
-      {#each members as member}
-        <MemberLabel
-          {member}
-          canBan={isAdmin && member.pubkey !== $account?.pubkey}
-          on:ban={banMember}
-        />
-      {/each}
-    </div>
-  </aside>
-  <main
-    style:grid-area="chat"
-    class="grid h-full"
-    style:grid-template-rows="75vh min-content"
-  >
-    <section class="row-span-9 overflow-y-auto pr-4">
-      <div class="flex flex-col h-full">
-        <div class="h-full overflow-x-hidden overflow-y-auto">
-          {#each messages as message (message.id)}
+
+  <div class="flex min-h-0 flex-1">
+    <aside
+      class="hidden w-60 shrink-0 overflow-y-auto border-r border-slate-200 bg-white p-4 md:block"
+    >
+      <GroupsList current={sidebarIsMember ? sidebarGroup : null} />
+
+      {#if relayChannels.length}
+        <div class="mt-6">
+          <h3
+            class="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400"
+          >
+            groups on this relay
+          </h3>
+          {#each relayChannels as channel (channel.id)}
+            {@const joined = !!(
+              $account &&
+              relayMemberships[channel.id]?.includes($account.pubkey)
+            )}
+            {@const unread =
+              channel.id !== id &&
+              (groupActivity[channel.id] || 0) > (lastReads[channel.id] || 0)}
             <div
-              class="grid gap-2 items-center hover:bg-emerald-100 group"
-              style:grid-template-columns="120px auto 99px"
-              id={`evt-${message.id.slice(-6)}`}
+              class="flex items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors"
+              class:bg-indigo-50={channel.id === id}
+              class:text-indigo-700={channel.id === id}
+              class:hover:bg-slate-100={channel.id !== id}
             >
-              <div class="self-end">
-                <UserLabel pubkey={message.pubkey} />
-              </div>
-              <div class="break-words">
-                {message.content}
-              </div>
-              <div class="flex justify-end text-stone-400 text-xs pr-1">
-                {#if message.created_at > Date.now() / 1000 - 60 * 60 * 3 && (isAdmin || message.pubkey === $account?.pubkey)}
-                  <!-- svelte-ignore a11y-no-static-element-interactions a11y-missing-attribute -->
-                  <!-- svelte-ignore a11y-click-events-have-key-events -->
-                  <a
-                    class="hover:text-red-600 cursor-pointer"
-                    on:click={deleteMessage}
-                    data-id={message.id}
-                    title="delete message"
-                  >
-                    ×
-                  </a>
-                  &nbsp;
-                {/if}
-                <span title={new Date(message.created_at * 1000).toString()}>
-                  {humanDate(message.created_at)}
-                </span>
-              </div>
+              {#if channel.id === id}
+                <span class="truncate font-medium" title={channel.id}
+                  >#{channel.name || channel.id}</span
+                >
+              {:else}
+                <a
+                  class="cursor-pointer truncate hover:underline"
+                  class:text-emerald-600={joined}
+                  title={channel.id}
+                  href={`/${host}'${channel.id}`}
+                  >#{channel.name || channel.id}</a
+                >
+              {/if}
+              {#if unread}
+                <span
+                  class="h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-500"
+                  title="new messages"
+                />
+              {/if}
             </div>
           {/each}
         </div>
-      </div>
-    </section>
-    <section>
-      {#if isMember}
-        <form
-          on:submit|preventDefault={sendMessage}
-          class="grid grid-cols-7 pt-4 mb-2 h-full py-4"
-        >
-          <textarea
-            class="h-full w-full bg-stone-100 col-span-6"
-            class:bg-stone-100={isSending}
-            placeholder={isSending
-              ? 'submitting...'
-              : !isMember
-              ? 'you are not a member of this group'
-              : 'type a message here (press Enter to send)'}
-            bind:value={text}
-            on:input={saveToLocalStorage}
-            on:keydown={onKeyDown}
-            readonly={isSending}
-          />
-          <div class="col-span-1 pl-2">
+      {/if}
+    </aside>
+
+    <main class="flex min-w-0 flex-1 flex-col">
+      <section class="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-4 py-3">
+        {#if !eoseHappened && messages.length === 0}
+          <div class="flex h-full items-center justify-center text-sm text-slate-400">
+            loading messages…
+          </div>
+        {/if}
+        {#each messages as message (message.id)}
+          {@const replyId = replyRefOf(message)}
+          {@const replyMsg = replyId
+            ? messages.find(m => m.id === replyId)
+            : undefined}
+          {@const body = renderMarkdown(
+            message.content,
+            parseImetaTags(message.tags)
+          )}
+          {@const chips = aggregateReactions(reactions[message.id])}
+          <!-- custom emoji live on the relay's blossom media endpoint too,
+               so the chip row goes through the same authorized loader -->
+          {@const chipsKey = chips.map(c => `${c.key}:${c.count}`).join(',')}
+          <div
+            class="group grid items-baseline gap-3 rounded-lg px-2 py-1 transition-colors hover:bg-white"
+            style:grid-template-columns="150px minmax(0, 1fr) auto"
+            id={`evt-${message.id.slice(-6)}`}
+          >
+            <div class="min-w-0 self-start">
+              <UserLabel pubkey={message.pubkey} relays={chatRelays} />
+            </div>
+            <div class="min-w-0 text-sm leading-relaxed text-slate-800">
+              {#if replyId}
+                <!-- svelte-ignore a11y-no-static-element-interactions a11y-click-events-have-key-events -->
+                <div
+                  class="mb-0.5 flex cursor-pointer items-center gap-1 text-xs text-slate-400 transition-colors hover:text-slate-600"
+                  on:click={() => scrollToMessage(replyId)}
+                  title="jump to the original message"
+                >
+                  <span class="shrink-0">↩</span>
+                  <span class="truncate italic">
+                    {replyMsg
+                      ? replyMsg.content
+                      : `${replyId.slice(0, 8)}…`}
+                  </span>
+                </div>
+              {/if}
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              <div class="markdown-body break-words" use:enhanceMedia={{body, host: mediaHost}}>
+                {@html body}
+              </div>
+              {#if chips.length}
+                <div
+                  class="mt-1 flex flex-wrap gap-1"
+                  use:enhanceMedia={{body: chipsKey, host: mediaHost}}
+                >
+                  {#each chips as chip (chip.key)}
+                    <button
+                      class="flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition-colors"
+                      class:border-indigo-300={!!chip.mine}
+                      class:bg-indigo-50={!!chip.mine}
+                      class:text-indigo-700={!!chip.mine}
+                      class:border-slate-200={!chip.mine}
+                      class:bg-white={!chip.mine}
+                      class:text-slate-600={!chip.mine}
+                      class:hover:bg-slate-100={!chip.mine && isMember}
+                      class:cursor-default={!isMember}
+                      disabled={!isMember}
+                      on:click={() => toggleReaction(message, chip)}
+                      title={chip.mine
+                        ? 'remove your reaction'
+                        : isMember
+                          ? 'react with the same emoji'
+                          : `${chip.count} reaction(s)`}
+                    >
+                      {#if chip.url}
+                        <!-- src is set by enhanceMedia, not by svelte: a
+                             re-render (reacting, counts changing) would
+                             otherwise reset an authorized blob: URL back
+                             to the bare one and break the image -->
+                        <img
+                          class="h-4 w-4 object-contain"
+                          data-src={chip.url}
+                          alt={chip.key}
+                        />
+                      {:else}
+                        <span>{chip.text}</span>
+                      {/if}
+                      <span>{chip.count}</span>
+                    </button>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+            <div
+              class="flex items-center justify-end gap-1.5 text-xs text-slate-400"
+            >
+              {#if isMember}
+                <button
+                  class="cursor-pointer opacity-0 transition-opacity grayscale hover:grayscale-0 group-hover:opacity-100"
+                  on:click={() => react(message, '+')}
+                  title="react with 👍"
+                >
+                  👍
+                </button>
+                <button
+                  class="cursor-pointer opacity-0 transition-opacity grayscale hover:grayscale-0 group-hover:opacity-100"
+                  on:click={() => react(message, '❤️')}
+                  title="react with ❤️"
+                >
+                  ❤️
+                </button>
+              {/if}
+              {#if message.created_at > Date.now() / 1000 - 60 * 60 * 3 && (isAdmin || message.pubkey === $account?.pubkey)}
+                <!-- svelte-ignore a11y-no-static-element-interactions a11y-missing-attribute -->
+                <!-- svelte-ignore a11y-click-events-have-key-events -->
+                <a
+                  class="cursor-pointer opacity-0 transition-opacity hover:text-red-500 group-hover:opacity-100"
+                  on:click={deleteMessage}
+                  data-id={message.id}
+                  title="delete message"
+                >
+                  ×
+                </a>
+              {/if}
+              <span title={new Date(message.created_at * 1000).toString()}>
+                {humanDate(message.created_at)}
+              </span>
+            </div>
+          </div>
+        {/each}
+      </section>
+
+      <section class="shrink-0 border-t border-slate-200 bg-white p-4">
+        {#if isMember}
+          <form
+            on:submit|preventDefault={sendMessage}
+            class="flex items-stretch gap-3"
+          >
+            <textarea
+              rows="2"
+              class="min-h-[3rem] flex-1 resize-none rounded-xl border-slate-300 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+              class:bg-slate-100={isSending}
+              placeholder={isSending
+                ? 'submitting...'
+                : 'type a message here (press Enter to send)'}
+              bind:value={text}
+              on:input={saveToLocalStorage}
+              on:keydown={onKeyDown}
+              readonly={isSending}
+            />
             <button
-              class="h-full w-full px-4 py-2 text-white rounded transition-colors"
-              class:bg-blue-500={!isSending}
-              class:hover:bg-blue-400={!isSending}
-              class:bg-stone-400={isSending}
+              class="shrink-0 rounded-xl px-6 font-medium text-white shadow-sm transition-colors"
+              class:bg-indigo-600={!isSending}
+              class:hover:bg-indigo-500={!isSending}
+              class:bg-slate-400={isSending}
               disabled={isSending || !group?.id || !relay}
             >
               send
             </button>
+          </form>
+        {:else if group?.public && $account}
+          <div class="flex justify-center py-2">
+            <button
+              class="rounded-xl bg-indigo-600 px-10 py-3 text-lg font-medium text-white shadow-md transition-colors hover:bg-indigo-500 disabled:bg-slate-400"
+              on:click={askToJoin}
+              disabled={isSending}>join this group</button
+            >
           </div>
-        </form>
-      {:else if group?.public && $account}
-        <div class="m-8 w-full">
-          <button
-            class="p-8 h-full w-full text-2xl bg-blue-500 hover:bg-blue-400 text-white rounded transition-colors"
-            on:click={askToJoin}
-            disabled={isSending}>join</button
+        {:else}
+          <p
+            class="rounded-xl bg-slate-100 p-4 text-center text-sm text-slate-500"
           >
+            you are not a member of this group
+          </p>
+        {/if}
+      </section>
+    </main>
+
+    <aside
+      class="hidden w-60 shrink-0 overflow-y-auto border-l border-slate-200 bg-white p-4 lg:block"
+    >
+      <h3
+        class="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400"
+      >
+        admins
+      </h3>
+      {#each admins as admin}
+        <div class="py-0.5">
+          <MemberLabel member={admin} relays={chatRelays} />
         </div>
-      {:else}
-        <p class="p-6 text-center border border-stone-200 m-2">
-          you are not a member of this group
-        </p>
+      {/each}
+      <h3
+        class="mb-3 mt-6 text-xs font-semibold uppercase tracking-wider text-slate-400"
+      >
+        members
+      </h3>
+      {#each members as member}
+        <div class="py-0.5">
+          <MemberLabel
+            {member}
+            relays={chatRelays}
+            canBan={isAdmin && member.pubkey !== $account?.pubkey}
+            on:ban={banMember}
+          />
+        </div>
+      {/each}
+
+      {#if isAdmin && group}
+        <h3
+          class="mb-3 mt-6 text-xs font-semibold uppercase tracking-wider text-slate-400"
+        >
+          group settings
+        </h3>
+        <label
+          class="flex cursor-pointer items-center gap-2 py-1 text-sm text-slate-700"
+          title="only members can read messages"
+        >
+          <input
+            type="checkbox"
+            class="rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+            checked={!group.public}
+            disabled={isSending}
+            on:change={e =>
+              setGroupStatus(e.currentTarget.checked, !group?.open)}
+          />
+          private
+        </label>
+        <label
+          class="flex cursor-pointer items-center gap-2 py-1 text-sm text-slate-700"
+          title="joining requires admin approval"
+        >
+          <input
+            type="checkbox"
+            class="rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+            checked={!group.open}
+            disabled={isSending}
+            on:change={e =>
+              setGroupStatus(!group?.public, e.currentTarget.checked)}
+          />
+          closed
+        </label>
       {/if}
-    </section>
-  </main>
+    </aside>
+  </div>
 </div>
+
+<style>
+  /* message bodies are rendered from markdown as raw html, so their
+     styling can't use svelte's scoped class rewriting */
+  .markdown-body :global(p) {
+    margin: 0;
+  }
+  .markdown-body :global(p + p),
+  .markdown-body :global(ul),
+  .markdown-body :global(ol),
+  .markdown-body :global(blockquote),
+  .markdown-body :global(table) {
+    margin-top: 0.375rem;
+  }
+  .markdown-body :global(a) {
+    color: rgb(79 70 229);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .markdown-body :global(a:hover) {
+    color: rgb(67 56 202);
+  }
+  .markdown-body :global(code) {
+    border-radius: 0.25rem;
+    background: rgb(241 245 249);
+    padding: 0.05rem 0.3rem;
+    font-size: 0.8125rem;
+  }
+  .markdown-body :global(pre) {
+    margin: 0.25rem 0;
+    overflow-x: auto;
+    border-radius: 0.5rem;
+    background: rgb(30 41 59);
+    padding: 0.5rem 0.75rem;
+    color: rgb(241 245 249);
+    font-size: 0.75rem;
+    line-height: 1.625;
+  }
+  .markdown-body :global(pre code) {
+    background: transparent;
+    padding: 0;
+    color: inherit;
+    font-size: inherit;
+  }
+  .markdown-body :global(.md-image-link) {
+    display: inline-block;
+    margin-top: 0.25rem;
+  }
+  .markdown-body :global(img) {
+    max-height: 20rem;
+    max-width: min(100%, 28rem);
+    border-radius: 0.5rem;
+    border: 1px solid rgb(226 232 240);
+    object-fit: contain;
+    background: rgb(248 250 252);
+  }
+  .markdown-body :global(blockquote) {
+    border-left: 3px solid rgb(203 213 225);
+    padding-left: 0.625rem;
+    color: rgb(71 85 105);
+  }
+  .markdown-body :global(ul) {
+    list-style: disc;
+    padding-left: 1.25rem;
+  }
+  .markdown-body :global(ol) {
+    list-style: decimal;
+    padding-left: 1.25rem;
+  }
+  .markdown-body :global(h1),
+  .markdown-body :global(h2),
+  .markdown-body :global(h3),
+  .markdown-body :global(h4) {
+    margin-top: 0.375rem;
+    font-weight: 600;
+  }
+  .markdown-body :global(table) {
+    display: block;
+    overflow-x: auto;
+    border-collapse: collapse;
+  }
+  .markdown-body :global(th),
+  .markdown-body :global(td) {
+    border: 1px solid rgb(226 232 240);
+    padding: 0.125rem 0.5rem;
+  }
+</style>

--- a/src/pages/SelectPage.svelte
+++ b/src/pages/SelectPage.svelte
@@ -3,12 +3,11 @@
   import {
     type Group,
     type GroupReference,
-    subscribeRelayGroups,
     parseGroupCode,
     encodeGroupReference
   } from 'nostr-tools/nip29'
 
-  import {pool} from '../lib/nostr.ts'
+  import {account, subscribeRelayGroupsWithAuth} from '../lib/nostr.ts'
   import Header from '../components/Header.svelte'
   import GroupsList from '../components/GroupsList.svelte'
   import {afterUpdate, onDestroy} from 'svelte'
@@ -17,9 +16,11 @@
 
   let gr: GroupReference = {id: '', host: ''}
   let status: 'connecting' | 'connected' | 'failed' | null = null
+  let errorMessage = ''
   let code = ''
   let cancel: () => void
   let channels: Group[] = []
+  let memberships: Record<string, string[]> = {}
 
   afterUpdate(() => {
     if (initialHost) {
@@ -43,15 +44,20 @@
       channels = []
     }
     status = 'connecting'
+    errorMessage = ''
 
-    cancel = subscribeRelayGroups(pool, gr.host, {
-      ongroups(groups: Group[]) {
+    cancel = subscribeRelayGroupsWithAuth(gr.host, {
+      ongroups(groups: Group[], m: Record<string, string[]>) {
         status = 'connected'
-        channels = groups
+        // never let a racing empty snapshot blank out a visible list
+        if (groups.length || !channels.length) channels = groups
+        if (Object.keys(m).length || !Object.keys(memberships).length)
+          memberships = m
       },
       onerror(err: Error) {
         console.warn('failed to load groups from relay', gr.host, err)
         status = 'failed'
+        errorMessage = err.message
       }
     })
   }, 400)
@@ -61,78 +67,182 @@
     if (res) gr = res
   }
 
+  // nostr-tools' encodeGroupReference strips the protocol but not a
+  // trailing slash; a host like "relay.example.com/" would produce a
+  // two-segment path ("/relay.example.com/'id") and break routing
+  const encodeRef = (r: GroupReference) =>
+    encodeGroupReference({...r, host: r.host.trim().replace(/\/+$/, '')})
+
   const encode = debounce(() => {
-    code = gr ? encodeGroupReference(gr) : ''
+    code = gr ? encodeRef(gr) : ''
   }, 300)
+
+
+  // the "open" link must not wait for the debounced `encode`, otherwise a
+  // quick click right after selecting a group would navigate to "/"
+  let openHref = ''
+  $: if (gr.id !== '' && gr.host !== '') {
+    try {
+      openHref = '/' + encodeRef(gr)
+    } catch (err) {
+      openHref = ''
+    }
+  } else {
+    openHref = ''
+  }
 </script>
 
-<h1 class="text-2xl h-1/6">
+<div class="mx-auto flex min-h-screen max-w-6xl flex-col px-6 py-5">
   <Header />
-</h1>
-<div class="flex">
-  <column class="mr-8">
-    <GroupsList />
-  </column>
-  <column class="">
-    <div class="mt-4">
-      type relay url: <input bind:value={gr.host} on:input={tryConnect} />
-    </div>
-    <div class="mt-2 pl-4">
-      {#if status === 'connecting' || status === 'failed'}
-        <span class="text-stone-500">{gr.host}</span>
-      {/if}
-      {#if status === 'connected'}
-        <span class="text-green-700">connected</span>
-      {:else if status === 'connecting'}
-        <span class="text-blue-700">connecting</span>
-      {:else if status === 'failed'}
-        <span class="text-red-700">failed to connect</span>
-      {/if}
+
+  <div class="mt-12 text-center">
+    <h2 class="text-3xl font-bold tracking-tight text-slate-900">
+      group chat over nostr
+    </h2>
+    <p class="mt-2 text-sm text-slate-500">
+      a barebones NIP-29 chat client — pick a relay, pick a group, start
+      talking
+    </p>
+  </div>
+
+  <div class="mt-12 grid items-start gap-6 lg:grid-cols-[16rem_minmax(0,1fr)]">
+    <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <GroupsList />
     </div>
 
-    <div class="mt-4">
-      {#each channels as channel}
-        <div class="mt-1 pl-4 max-h-64">
-          <div class="flex">
-            <!-- svelte-ignore a11y-no-static-element-interactions a11y-click-events-have-key-events -->
-            <div
-              class="cursor-pointer hover:underline text-blue-700"
-              on:click={() => {
-                gr.id = channel.id
-                encode()
-              }}
-            >
-              {channel.id}
-            </div>
-            <div class="ml-4 text-stone-600">{channel.name}</div>
-          </div>
-        </div>
-      {/each}
-    </div>
+    <div class="grid items-start gap-6 md:grid-cols-2">
+      <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h3 class="text-base font-semibold text-slate-900">
+          join a group on a relay
+        </h3>
+        <p class="mt-1 text-sm text-slate-500">
+          connect to a relay to browse its public groups
+        </p>
 
-    {#if status === 'connected'}
-      <div class="mt-4">
-        type group id: <input bind:value={gr.id} on:input={encode} />
-      </div>
-    {/if}
-
-    <div class="mt-4">
-      {#if gr.id !== '' && gr.host !== ''}
-        <a
-          class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-400 transition-colors"
-          href="/{code}">open</a
+        <label
+          class="mt-5 block text-xs font-medium uppercase tracking-wider text-slate-400"
+          for="relay-url">relay url</label
         >
-      {/if}
+        <input
+          id="relay-url"
+          class="mt-1.5 w-full rounded-lg border-slate-300 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          placeholder="groups.0xchat.com"
+          bind:value={gr.host}
+          on:input={tryConnect}
+        />
+        <div class="mt-1.5 h-5 text-sm">
+          {#if status === 'connected'}
+            <span class="inline-flex items-center gap-1.5 text-emerald-600">
+              <span class="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+              connected
+            </span>
+          {:else if status === 'connecting'}
+            <span class="inline-flex items-center gap-1.5 text-slate-400">
+              <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-slate-400" />
+              connecting…
+            </span>
+          {:else if status === 'failed'}
+            <span class="inline-flex items-center gap-1.5 text-red-600">
+              <span class="h-1.5 w-1.5 rounded-full bg-red-500" />
+              failed to connect
+            </span>
+          {/if}
+        </div>
+        {#if status === 'failed' && errorMessage}
+          <div class="mt-1 text-xs leading-relaxed text-red-500">
+            {errorMessage}
+          </div>
+        {/if}
+
+        {#if status === 'connected'}
+          {#if channels.length}
+            <div
+              class="mt-3 text-xs font-medium uppercase tracking-wider text-slate-400"
+            >
+              groups on this relay — click to enter
+            </div>
+            <div
+              class="mt-1.5 max-h-64 overflow-y-auto rounded-lg border border-slate-100"
+            >
+              {#each channels as channel (channel.id)}
+                {@const joined = !!(
+                  $account &&
+                  memberships[channel.id]?.includes($account.pubkey)
+                )}
+                <div
+                  class="flex items-center gap-2 px-3 py-1.5 text-sm transition-colors hover:bg-indigo-50"
+                >
+                  <a
+                    class="min-w-0 flex-1 truncate font-medium"
+                    class:text-emerald-600={joined}
+                    class:text-slate-700={!joined}
+                    title={channel.id}
+                    href={'/' + encodeRef({host: gr.host, id: channel.id})}
+                    >#{channel.name || channel.id}</a
+                  >
+                  {#if joined}
+                    <span
+                      class="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500"
+                      title="you are a member"
+                    />
+                  {/if}
+                </div>
+              {/each}
+            </div>
+          {:else}
+            <div class="mt-3 text-sm text-slate-400">
+              this relay lists no public groups — if you know a group id, type
+              it below
+            </div>
+          {/if}
+
+          <label
+            class="mt-4 block text-xs font-medium uppercase tracking-wider text-slate-400"
+            for="group-id">or type a group id</label
+          >
+          <input
+            id="group-id"
+            class="mt-1.5 w-full rounded-lg border-slate-300 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            bind:value={gr.id}
+            on:input={encode}
+          />
+        {/if}
+      </div>
+
+      <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h3 class="text-base font-semibold text-slate-900">
+          join with a group code
+        </h3>
+        <p class="mt-1 text-sm text-slate-500">got a code? paste it here</p>
+
+        <label
+          class="mt-5 block text-xs font-medium uppercase tracking-wider text-slate-400"
+          for="group-code">group code</label
+        >
+        <input
+          id="group-code"
+          class="mt-1.5 w-full rounded-lg border-slate-300 font-mono text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          placeholder="naddr1…"
+          bind:value={code}
+          on:input={parse}
+        />
+        <div class="mt-2 text-xs leading-relaxed text-slate-400">
+          a code someone shared with you, like
+          <span class="font-mono">naddr1…</span> or
+          <span class="font-mono">relay.host'group-id</span>
+        </div>
+      </div>
     </div>
-  </column>
-  <div class="flex items-center justify-center uppercase text-2xl mx-4">or</div>
-  <column class="">
-    <div class="mt-4 flex items-center">
-      type a group code: <input
-        class="ml-2"
-        bind:value={code}
-        on:input={parse}
-      />
+  </div>
+
+  {#if openHref !== ''}
+    <div class="mt-10 flex justify-center">
+      <a
+        class="rounded-xl bg-indigo-600 px-8 py-3 font-medium text-white shadow-md transition-colors hover:bg-indigo-500"
+        href={openHref}
+      >
+        open <span class="font-semibold">{gr.id}</span> on {gr.host} →
+      </a>
     </div>
-  </column>
+  {/if}
 </div>


### PR DESCRIPTION
Render message bodies as markdown with sanitised HTML, show images and NIP-25 reactions, fetch relay media that requires Blossom authorization, and rework the chat layout with per-group caching and unread markers.